### PR TITLE
Proto generator improvements

### DIFF
--- a/firebase-auth-admin/test/test-service-account.dart
+++ b/firebase-auth-admin/test/test-service-account.dart
@@ -1,0 +1,14 @@
+const String serviceAccountJson = '''
+{
+  "type": "service_account",
+  "project_id": "nozard-techlog",
+  "private_key_id": "79ecde71fe516329f4ff4c2f0169c7b4d08a594c",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCyvi7rPhSJDURE\noHf1MXCpZyFJp3Z02hk4R4/BTBifzgeks2j9vWo2riWf/uBgCmFURtJ0z22n127k\n+Poe9IG1blnhUq89Kmgc0nONzj3U07KoyzmlujKagEIVitvXejRDG0PO6nyPeHPI\nNmOPM7voU4EEeON/6479/kyYcBRNrf8iQCBgTYXZG4NhlJ7fEfVxJSRavP57S778\nLI25qXnflX5XbIuPn3cS/XL/za7L8eC0wFXO21uACd8UTgsjYt1OYEPYrHZNldVC\n6acLe5VC54ze+ZYLAmYE5MW4doTZLsYiyU4Z0jRn+5cHbWXBO7ktniNWzT+v9mqe\nSoY5gCydAgMBAAECggEARo3VnVvS5UpMUT56O1m5m9SuihFFK9jPLazprKYp7iJ4\nV+XNoqL64vyYs2/7B03xnz+ZYSxjn2XlSxKQQFnJPWGCrvNhYqZzlDTqEeZ/95tc\noU4ewjEeOmg4LaKzJnoBWR/RA0MByewE39nAMM199bXIboh9XIgR2GZhu6Y6DXLg\nzDb1uIJdNPUBLJLLaH4wOjQ4ai7LeS0+3aZvEo/OqTp2OFYui6tXCEngEx8V9T1z\n0KiW6q6Eig5AjmdcrzFuljpX8SQCqmC+lq7jjxT3TVytfoq2qb30zkIMa4DtOVmJ\nFy4qVFk7SR0yJTRzTjUoQM5hC2Sb+fEjef/Ee4gb7QKBgQDknE0JWZDEPQfpieR/\n4bpAiFLpG5rJrdkNFkVGvyJTUQu80UYvFCBKuT+6xMQIsBPA/3oRiEsyOUKpXhgD\nMsTx+GoJMZoyCoNfPNA8hjXlyYqohirm+aBU9bb44FgD1jZpRIyHne0JDNaeB58m\noYwgrES3+hzDTHZs3jbRRG+YywKBgQDIKGUh25mKB81v2RfwuRBongC/GN0YjLiR\n/ASfJvPL9+POJLg4Q7REsENK3qqtEAIYZ1vxdAVoMxZP/70/0TStZmZZah9NNswI\nC5EqVdhmY4XGGj4heKHIGo+OYo+bssuHiuQAxruy42/95NA1+S0K/hyrUn/7W+YQ\ngHuXKEzrNwKBgQDIx/nk51P89jk3xJL6Oe9R9CkVcNgun1BNbSzk6MOl9z1e1VJV\n0NBXsIGncF9X3gVLcVXthg29C4tfozNlw7YzamD+uCDcKF2fTJL7RUibC7qLLmMJ\nv14woCnWRXsny4C4Tas7BNoFI9ButPTzgdjHbWVhS/rtD//GuBffDcMRpwKBgQCt\nf5ZqSthEdY72LNA7sa8vgAZVn0/HP/OdVz8KVdFuNGoa/mlRHB7ei4tJEsoPSZkH\nXlCsc01cjSwCHEQHVWi8Bc8iIoMPgzhIoP4sHE2AMzR6C7Vffhl+Qse9PGIPLGSQ\nESyiH6ID5nHlOrngjyUkKjDfsJuPXpGGLFj1JdHG8QKBgAHXhrVSUUeO7YSGh1V/\n7+AnZcP6x44fq4uTaf4ErTIepIeUVXOsigg/m4wECCN2lMD/n9e6JTq7nEE725XS\nmcWM7Va8XB+RcJ5KCCuSvIbRjB4ZPHU2ZhaQFVJD4wBvX2L/wt/BmgIeNi58JEJ5\nY556cMJp4wvA++TBKkxwNYG/\n-----END PRIVATE KEY-----\n",
+  "client_email": "firebase-adminsdk-84e59@nozard-techlog.iam.gserviceaccount.com",
+  "client_id": "113558840754793903690",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/firebase-adminsdk-84e59%40nozard-techlog.iam.gserviceaccount.com"
+}
+''';

--- a/proto_mapper/proto_generator/CHANGELOG.md
+++ b/proto_mapper/proto_generator/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fixed broken links to example
 - Added support for multiple @proto and @mapProto annotated classes within a single .dart file
 - Added support for Map<?, ?>
+- Improved support for constructors of mapped PODO's
 
 ## 2.0.0
 

--- a/proto_mapper/proto_generator/CHANGELOG.md
+++ b/proto_mapper/proto_generator/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 2.0.1
 
 - Fixed broken links to example
+- Added support for multiple @proto and @mapProto annotated classes within a single .dart file
+- Added support for Map<?, ?>
 
 ## 2.0.0
 

--- a/proto_mapper/proto_generator/CHANGELOG.md
+++ b/proto_mapper/proto_generator/CHANGELOG.md
@@ -1,9 +1,12 @@
-## 2.0.1
+## 2.0.2
 
-- Fixed broken links to example
 - Added support for multiple @proto and @mapProto annotated classes within a single .dart file
 - Added support for Map<?, ?>
 - Improved support for constructors of mapped PODO's
+
+## 2.0.1
+
+- Fixed broken links to example
 
 ## 2.0.0
 

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generator.dart
@@ -1,12 +1,13 @@
-import 'package:proto_generator/src/proto/field_code_generators/double_field_code_generator.dart';
 import 'package:proto_generator/src/proto_common.dart';
 
 import 'field_code_generators/bool_field_code_generator.dart';
 import 'field_code_generators/datetime_field_code_generator.dart';
+import 'field_code_generators/double_field_code_generator.dart';
 import 'field_code_generators/duration_field_code_generator.dart';
 import 'field_code_generators/entity_field_code_generator.dart';
 import 'field_code_generators/generic_field_code_generator.dart';
 import 'field_code_generators/int_field_code_generator.dart';
+import 'field_code_generators/map_field_code_generator.dart';
 import 'field_code_generators/string_field_code_generator.dart';
 import 'field_descriptor.dart';
 
@@ -51,6 +52,9 @@ abstract class FieldCodeGenerator {
     }
     if (type.hasProto) {
       return EntityFieldCodeGenerator(fieldDescriptor, lineNumber);
+    }
+    if (type.isDartCoreMap) {
+      return MapFieldCodeGenerator(fieldDescriptor, lineNumber);
     }
     return GenericFieldCodeGenerator(fieldDescriptor, lineNumber);
   }

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/entity_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/entity_field_code_generator.dart
@@ -5,7 +5,7 @@ import '../field_descriptor.dart';
 import 'external_proto_name.dart';
 
 class EntityFieldCodeGenerator extends FieldCodeGenerator
-    implements ExternalProtoName {
+    implements ExternalProtoNames {
   EntityFieldCodeGenerator(FieldDescriptor fieldDescriptor, int lineNumber)
       : super(fieldDescriptor, lineNumber) {
     final fieldElementType = fieldDescriptor.itemType;
@@ -18,10 +18,10 @@ class EntityFieldCodeGenerator extends FieldCodeGenerator
         ? '$packageName.$fieldElementTypeName'
         : fieldElementTypeName;
 
-    _externalProtoName = _initExternalProtoName(fieldDescriptor);
+    _externalProtoNames = _initExternalProtoName(fieldDescriptor);
   }
 
-  String? _initExternalProtoName(FieldDescriptor fieldDescriptor) {
+  Iterable<String>? _initExternalProtoName(FieldDescriptor fieldDescriptor) {
     final fieldElementType = fieldDescriptor.itemType;
     final segments =
         fieldElementType.element!.source!.uri.pathSegments.toList();
@@ -30,12 +30,12 @@ class EntityFieldCodeGenerator extends FieldCodeGenerator
     var fileName = segments[segments.length - 1];
     fileName = fileName.substring(0, fileName.length - 4) + 'proto';
     segments[segments.length - 1] = fileName;
-    return segments.join('/');
+    return [segments.join('/')];
   }
 
-  String? _externalProtoName;
+  Iterable<String>? _externalProtoNames;
   @override
-  String? get externalProtoName => _externalProtoName;
+  Iterable<String>? get externalProtoNames => _externalProtoNames;
 
   String? _fieldType;
   @override

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/external_proto_name.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/external_proto_name.dart
@@ -1,3 +1,3 @@
-abstract class ExternalProtoName {
-  String? get externalProtoName;
+abstract class ExternalProtoNames {
+  Iterable<String>? get externalProtoNames;
 }

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
@@ -13,9 +13,12 @@ class MapFieldCodeGenerator extends FieldCodeGenerator
 
     final packageName = fieldElementType.packageName;
 
-    assert (fieldElementType is InterfaceType);
-    final keyTypeName = _fieldTypeName((fieldElementType as InterfaceType).typeArguments[0], fieldDescriptor.prefix);
-    final valueTypeName = _fieldTypeName((fieldElementType).typeArguments[1], fieldDescriptor.prefix);
+    assert(fieldElementType is InterfaceType);
+    final keyTypeName = _fieldTypeName(
+        (fieldElementType as InterfaceType).typeArguments[0],
+        fieldDescriptor.prefix);
+    final valueTypeName = _fieldTypeName(
+        (fieldElementType).typeArguments[1], fieldDescriptor.prefix);
 
     final fieldElementTypeName = '''map<$keyTypeName, $valueTypeName>''';
 
@@ -28,7 +31,8 @@ class MapFieldCodeGenerator extends FieldCodeGenerator
 
   Iterable<String>? _initExternalProtoNames(FieldDescriptor fieldDescriptor) {
     final names = <String>[];
-    final argumentTypes = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    final argumentTypes =
+        (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
     for (DartType argumentType in argumentTypes) {
       if (argumentType.isDartCoreString ||
           argumentType.isDartCoreInt ||

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
@@ -1,0 +1,71 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:proto_generator/src/proto_common.dart';
+
+import '../field_code_generator.dart';
+import '../field_descriptor.dart';
+import 'external_proto_name.dart';
+
+class MapFieldCodeGenerator extends FieldCodeGenerator
+    implements ExternalProtoNames {
+  MapFieldCodeGenerator(FieldDescriptor fieldDescriptor, int lineNumber)
+      : super(fieldDescriptor, lineNumber) {
+    final fieldElementType = fieldDescriptor.itemType;
+
+    final packageName = fieldElementType.packageName;
+
+    assert (fieldElementType is InterfaceType);
+    final keyTypeName = _fieldTypeName((fieldElementType as InterfaceType).typeArguments[0], fieldDescriptor.prefix);
+    final valueTypeName = _fieldTypeName((fieldElementType).typeArguments[1], fieldDescriptor.prefix);
+
+    final fieldElementTypeName = '''map<$keyTypeName, $valueTypeName>''';
+
+    _fieldType = packageName != ''
+        ? '$packageName.$fieldElementTypeName'
+        : fieldElementTypeName;
+
+    _externalProtoNames = _initExternalProtoNames(fieldDescriptor);
+  }
+
+  Iterable<String>? _initExternalProtoNames(FieldDescriptor fieldDescriptor) {
+    final names = <String>[];
+    final argumentTypes = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    for (DartType argumentType in argumentTypes) {
+      if (argumentType.isDartCoreString ||
+          argumentType.isDartCoreInt ||
+          argumentType.isDartCoreDouble ||
+          argumentType.isDartCoreNum ||
+          argumentType.isDartCoreBool) {
+        continue;
+      }
+      final segments = argumentType.element!.source!.uri.pathSegments.toList();
+      final lastSrc = segments.lastIndexOf('src');
+      if (lastSrc != -1) segments.removeRange(0, lastSrc + 1);
+      var fileName = segments[segments.length - 1];
+      fileName = fileName.substring(0, fileName.length - 4) + 'proto';
+      segments[segments.length - 1] = fileName;
+      names.add(segments.join('/'));
+    }
+    return names;
+  }
+
+  Iterable<String>? _externalProtoNames;
+  @override
+  Iterable<String>? get externalProtoNames => _externalProtoNames;
+
+  String? _fieldType;
+  @override
+  String? get fieldType => _fieldType;
+
+  String _fieldTypeName(DartType keyType, String prefix) {
+    if (keyType.isDartCoreString) {
+      return 'string';
+    } else if (keyType.isDartCoreInt) {
+      return 'int32';
+    } else if (keyType.isDartCoreDouble) {
+      return 'int64';
+    } else if (keyType.isDartCoreBool) {
+      return 'bool';
+    }
+    return '$prefix${keyType.getDisplayString(withNullability: true)}';
+  }
+}

--- a/proto_mapper/proto_generator/lib/src/proto/proto_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/proto_generator.dart
@@ -39,7 +39,8 @@ class ProtoGenerator extends GeneratorForAnnotation<Proto> {
       syntax = '''syntax = "proto3";
       ''';
       alreadyImported.clear();
-      alreadyImported.addAll(buildStep.allowedOutputs.map((e) => e.path.substring(e.path.lastIndexOf('/') + 1)));
+      alreadyImported.addAll(buildStep.allowedOutputs
+          .map((e) => e.path.substring(e.path.lastIndexOf('/') + 1)));
     }
 
     var ret = classElement.kind == ElementKind.ENUM

--- a/proto_mapper/proto_generator/lib/src/proto_common.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_common.dart
@@ -27,12 +27,15 @@ String createFieldDeclarations(
       lineNumber++;
     }
 
-    if (fieldCodeGenerator is! ExternalProtoName) continue;
-    var externalProtoName =
-        (fieldCodeGenerator as ExternalProtoName).externalProtoName;
-    if (externalProtoName != null &&
-        !externalProtoNames.contains(externalProtoName)) {
-      externalProtoNames.add(externalProtoName);
+    if (fieldCodeGenerator is! ExternalProtoNames) continue;
+    var externalProtoNames2 =
+        (fieldCodeGenerator as ExternalProtoNames).externalProtoNames;
+    if (externalProtoNames2 != null) {
+      for (String externalProtoName in externalProtoNames2) {
+        if (!externalProtoNames.contains(externalProtoName)) {
+          externalProtoNames.add(externalProtoName);
+        }
+      }
     }
   }
 

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generator.dart
@@ -1,6 +1,6 @@
 import 'package:decimal/decimal.dart';
-
 import 'package:proto_annotations/proto_annotations.dart';
+
 import 'field_code_generators/bool_field_code_generator.dart';
 import 'field_code_generators/datetime_field_code_generator.dart';
 import 'field_code_generators/decimal_field_code_generator.dart';
@@ -11,6 +11,7 @@ import 'field_code_generators/generic_field_code_generator.dart';
 import 'field_code_generators/int_field_code_generator.dart';
 import 'field_code_generators/iterable_field_code_generator.dart';
 import 'field_code_generators/list_field_code_generator.dart';
+import 'field_code_generators/map_field_code_generator.dart';
 import 'field_code_generators/set_field_code_generator.dart';
 import 'field_code_generators/string_field_code_generator.dart';
 import 'field_descriptor.dart';
@@ -94,6 +95,13 @@ abstract class FieldCodeGenerator {
     }
     if (fieldDescriptor.fieldElementType.isDartCoreList) {
       return ListFieldCodeGenerator(
+        fieldDescriptor,
+        refName: refName,
+        protoRefName: protoRefName,
+      );
+    }
+    if (fieldDescriptor.fieldElementType.isDartCoreMap) {
+      return MapFieldCodeGenerator(
         fieldDescriptor,
         refName: refName,
         protoRefName: protoRefName,

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
@@ -16,7 +16,8 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
         );
 
   String get _valueToProto {
-    var typeArguments = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    var typeArguments =
+        (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
     final keyFieldTypeName = typeArguments[0];
     final valueFieldTypeName = typeArguments[1];
 
@@ -33,7 +34,8 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
         parameterType.isDartCoreString) {
       return parameterName;
     }
-    final fieldTypeName = parameterType.getDisplayString(withNullability: false);
+    final fieldTypeName =
+        parameterType.getDisplayString(withNullability: false);
     if (fieldTypeName == (Decimal).toString()) {
       return '$parameterName.toString()';
     }
@@ -70,7 +72,8 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
         parameterType.isDartCoreString) {
       return parameterName;
     }
-    final fieldTypeName = parameterType.getDisplayString(withNullability: false);
+    final fieldTypeName =
+        parameterType.getDisplayString(withNullability: false);
     if (fieldTypeName == (Decimal).toString()) {
       return 'Decimal.parse($parameterName)';
     }
@@ -84,9 +87,9 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
     return ''' const \$${fieldTypeName}ProtoMapper().fromProto($parameterName)''';
   }
 
-
   String get _protoToValue {
-    var typeArguments = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    var typeArguments =
+        (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
     final keyFieldTypeName = typeArguments[0];
     final valueFieldTypeName = typeArguments[1];
 
@@ -99,6 +102,5 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
   @override
   String get fromProtoNonNullableExpression =>
       // '''List<${fieldDescriptor.parameterTypeName}>.unmodifiable($ref$protoFieldName.map((e) => $_protoToValue))''';
-  '''$ref$protoFieldName.map((k, v) => $_protoToValue)''';
-
+      '''$ref$protoFieldName.map((k, v) => $_protoToValue)''';
 }

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
@@ -1,0 +1,104 @@
+import 'package:analyzer/dart/element/type.dart';
+import 'package:decimal/decimal.dart';
+
+import '../field_code_generator.dart';
+import '../field_descriptor.dart';
+
+class MapFieldCodeGenerator extends FieldCodeGenerator {
+  MapFieldCodeGenerator(
+    FieldDescriptor fieldDescriptor, {
+    String refName = FieldCodeGenerator.defaultRefName,
+    String protoRefName = FieldCodeGenerator.defaultProtoRefName,
+  }) : super(
+          fieldDescriptor,
+          refName: refName,
+          protoRefName: protoRefName,
+        );
+
+  String get _valueToProto {
+    var typeArguments = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    final keyFieldTypeName = typeArguments[0];
+    final valueFieldTypeName = typeArguments[1];
+
+    final keyToProto = _toProto('k', keyFieldTypeName);
+    final valueToProto = _toProto('v', valueFieldTypeName);
+
+    return '''MapEntry($keyToProto, $valueToProto)''';
+  }
+
+  String _toProto(String parameterName, DartType parameterType) {
+    if (parameterType.isDartCoreBool ||
+        parameterType.isDartCoreDouble ||
+        parameterType.isDartCoreInt ||
+        parameterType.isDartCoreString) {
+      return parameterName;
+    }
+    final fieldTypeName = parameterType.getDisplayString(withNullability: false);
+    if (fieldTypeName == (Decimal).toString()) {
+      return '$parameterName.toString()';
+    }
+    if (fieldTypeName == (DateTime).toString()) {
+      return 'Int64($parameterName.millisecondsSinceEpoch)';
+    }
+    if (fieldTypeName == (Duration).toString()) {
+      return '$parameterName.inMilliseconds.toDouble()';
+    }
+    return ''' const \$${fieldTypeName}ProtoMapper().toProto($parameterName)''';
+  }
+
+  String get _toProtoConversion {
+    return '.map((k, v) => $_valueToProto)';
+  }
+
+  @override
+  String get toProtoMap => fieldDescriptor.isNullable
+      ? '''        
+      $protoRef$protoFieldName
+        .addAll($ref$fieldName${_toProtoConversion != '' ? '?' : ''}$_toProtoConversion ?? {});
+        $hasValueToProtoMap;
+      '''
+      : '''
+        $protoRef$protoFieldName
+          .addAll($ref$fieldName$_toProtoConversion);
+
+      ''';
+
+  String _toValue(String parameterName, DartType parameterType) {
+    if (parameterType.isDartCoreBool ||
+        parameterType.isDartCoreDouble ||
+        parameterType.isDartCoreInt ||
+        parameterType.isDartCoreString) {
+      return parameterName;
+    }
+    final fieldTypeName = parameterType.getDisplayString(withNullability: false);
+    if (fieldTypeName == (Decimal).toString()) {
+      return 'Decimal.parse($parameterName)';
+    }
+    if (fieldTypeName == (DateTime).toString()) {
+      return 'DateTime.fromMillisecondsSinceEpoch($parameterName.toInt())';
+    }
+    if (fieldTypeName == (Duration).toString()) {
+      return 'Duration(milliseconds: $parameterName.toInt())';
+    }
+
+    return ''' const \$${fieldTypeName}ProtoMapper().fromProto($parameterName)''';
+  }
+
+
+  String get _protoToValue {
+    var typeArguments = (fieldDescriptor.fieldElementType as InterfaceType).typeArguments;
+    final keyFieldTypeName = typeArguments[0];
+    final valueFieldTypeName = typeArguments[1];
+
+    final keyToProto = _toValue('k', keyFieldTypeName);
+    final valueToProto = _toValue('v', valueFieldTypeName);
+
+    return '''MapEntry($keyToProto, $valueToProto)''';
+  }
+
+  @override
+  String get fromProtoNonNullableExpression =>
+      // '''List<${fieldDescriptor.parameterTypeName}>.unmodifiable($ref$protoFieldName.map((e) => $_protoToValue))''';
+  '''$ref$protoFieldName.map((k, v) => $_protoToValue)''';
+
+}

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/proto_mapper_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/proto_mapper_generator.dart
@@ -48,7 +48,7 @@ class ProtoMapperGenerator extends GeneratorForAnnotation<MapProto> {
     // toProto is just fields, regardless of constructors...
     for (var fieldDescriptor in fieldDescriptors) {
       final fieldCodeGenerator =
-        FieldCodeGenerator.fromFieldDescriptor(fieldDescriptor);
+          FieldCodeGenerator.fromFieldDescriptor(fieldDescriptor);
       finalToProtoFieldBuffer.writeln(fieldCodeGenerator.toProtoMap);
     }
 
@@ -57,37 +57,44 @@ class ProtoMapperGenerator extends GeneratorForAnnotation<MapProto> {
       var fromProtoFieldBuffer = StringBuffer();
       var constructorFieldBuffer = StringBuffer();
       var nonCoveredFields = List<FieldDescriptor>.from(fieldDescriptors);
-      constructorName = constructor.name.isNotEmpty ? ".${constructor.name}" : constructor.name;
+      constructorName = constructor.name.isNotEmpty
+          ? ".${constructor.name}"
+          : constructor.name;
 
       // First use the available constructor parameters (this way we preserve unnamed constructor arg order)
       for (ParameterElement constructorParameter in constructor.parameters) {
-        final fieldDescriptorList = fieldDescriptors.where((element) => element.name == constructorParameter.name);
+        final fieldDescriptorList = fieldDescriptors
+            .where((element) => element.name == constructorParameter.name);
         if (fieldDescriptorList.isEmpty) {
           // If not found, there's not much we can do...
           continue;
         }
         final fieldCodeGenerator =
-          FieldCodeGenerator.fromFieldDescriptor(fieldDescriptorList.first);
+            FieldCodeGenerator.fromFieldDescriptor(fieldDescriptorList.first);
         // INLINE
         var constructorMap = fieldCodeGenerator.constructorMap;
         if (!constructorParameter.isNamed) {
-          constructorMap = constructorMap.substring(constructorParameter.nameLength + 1);
+          constructorMap =
+              constructorMap.substring(constructorParameter.nameLength + 1);
         }
         constructorFieldBuffer.writeln(constructorMap);
         // Remove from nonCoveredFields, as we have it covered...
-        nonCoveredFields.removeWhere((element) => element.name == constructorParameter.name);
+        nonCoveredFields.removeWhere(
+            (element) => element.name == constructorParameter.name);
       }
       // Then append the (non-final) fields not included within the constructor
       // Final fields will be skipped, as they can't be set anyway...
       for (var fieldDescriptor in nonCoveredFields) {
         final fieldCodeGenerator =
-          FieldCodeGenerator.fromFieldDescriptor(fieldDescriptor);
+            FieldCodeGenerator.fromFieldDescriptor(fieldDescriptor);
         if (!fieldDescriptor.isFinal) {
           var fromProtoMap = fieldCodeGenerator.fromProtoMap;
           fromProtoFieldBuffer.writeln('  ..$fromProtoMap');
         }
       }
-      if (nonCoveredFields.isEmpty || (finalFromProtoFieldBuffer.isEmpty && finalConstructorFieldBuffer.isEmpty)) {
+      if (nonCoveredFields.isEmpty ||
+          (finalFromProtoFieldBuffer.isEmpty &&
+              finalConstructorFieldBuffer.isEmpty)) {
         finalFromProtoFieldBuffer = StringBuffer(fromProtoFieldBuffer);
         finalConstructorFieldBuffer = StringBuffer(constructorFieldBuffer);
       }

--- a/proto_mapper/proto_generator/lib/src/proto_services_mapper/proto_services_service_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_services_mapper/proto_services_service_generator.dart
@@ -145,12 +145,15 @@ class _Generator extends ProtoServicesGeneratorBase {
     
     ''');
 
-    final externalProtoName =
-        _getExternalProtoName(methodDescriptor.returnType);
+    final externalProtoNames2 =
+        _getExternalProtoNames(methodDescriptor.returnType);
 
-    if (externalProtoName != '' &&
-        !externalProtoNames.contains(externalProtoName)) {
-      externalProtoNames.add(externalProtoName);
+    if (externalProtoNames2.isNotEmpty) {
+      for (String externalProtoName in externalProtoNames2) {
+        if (!externalProtoNames.contains(externalProtoName)) {
+          externalProtoNames.add(externalProtoName);
+        }
+      }
     }
   }
 
@@ -283,11 +286,11 @@ class _Generator extends ProtoServicesGeneratorBase {
     return ret;
   }
 
-  String _getExternalProtoName(DartType type) {
+  Iterable<String> _getExternalProtoNames(DartType type) {
     var fieldElementType = type.finalType;
     var segments = fieldElementType.element?.source?.uri.pathSegments.toList();
     if (segments == null) {
-      return '';
+      return [];
     }
     var lastSrc = segments.lastIndexOf('src');
     if (lastSrc != -1) segments.removeRange(0, lastSrc + 1);
@@ -295,7 +298,7 @@ class _Generator extends ProtoServicesGeneratorBase {
     fileName = fileName.substring(0, fileName.length - 4) + 'proto';
     segments[segments.length - 1] = fileName;
     final ret = segments.join('/');
-    return ret;
+    return [ret];
   }
 
   String _getProtoMappedParameterType(

--- a/proto_mapper/proto_generator/pubspec.yaml
+++ b/proto_mapper/proto_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: proto_generator
 description: Code generation of .proto and Dart mapper classes to facilitate the usage of PODOs (plain-old-dart-objects) with gRPC
 homepage: https://github.com/squarealfa/dart_framework/tree/main/proto_mapper/proto_generator
 repository: https://github.com/squarealfa/dart_framework
-version: 2.0.0
+version: 2.0.2
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/proto_mapper/test/lib/grpc/constructors_host.pb.dart
+++ b/proto_mapper/test/lib/grpc/constructors_host.pb.dart
@@ -1,0 +1,1242 @@
+///
+//  Generated code. Do not modify.
+//  source: constructors_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class GConstructObject1 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject1',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  GConstructObject1._() : super();
+  factory GConstructObject1({
+    $core.String? name,
+    $core.int? number,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    return _result;
+  }
+  factory GConstructObject1.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject1.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject1 clone() => GConstructObject1()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject1 copyWith(void Function(GConstructObject1) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject1))
+          as GConstructObject1; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject1 create() => GConstructObject1._();
+  GConstructObject1 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject1> createRepeated() =>
+      $pb.PbList<GConstructObject1>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject1 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject1>(create);
+  static GConstructObject1? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get number => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set number($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumber() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumber() => clearField(2);
+}
+
+class GListOfConstructObject1 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject1',
+      createEmptyInstance: create)
+    ..pc<GConstructObject1>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject1.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject1._() : super();
+  factory GListOfConstructObject1({
+    $core.Iterable<GConstructObject1>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject1.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject1.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject1 clone() =>
+      GListOfConstructObject1()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject1 copyWith(
+          void Function(GListOfConstructObject1) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject1))
+          as GListOfConstructObject1; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject1 create() => GListOfConstructObject1._();
+  GListOfConstructObject1 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject1> createRepeated() =>
+      $pb.PbList<GListOfConstructObject1>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject1 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject1>(create);
+  static GListOfConstructObject1? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject1> get items => $_getList(0);
+}
+
+class GConstructObject2 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject2',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  GConstructObject2._() : super();
+  factory GConstructObject2({
+    $core.String? name,
+    $core.int? number,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    return _result;
+  }
+  factory GConstructObject2.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject2.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject2 clone() => GConstructObject2()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject2 copyWith(void Function(GConstructObject2) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject2))
+          as GConstructObject2; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject2 create() => GConstructObject2._();
+  GConstructObject2 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject2> createRepeated() =>
+      $pb.PbList<GConstructObject2>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject2 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject2>(create);
+  static GConstructObject2? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get number => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set number($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumber() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumber() => clearField(2);
+}
+
+class GListOfConstructObject2 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject2',
+      createEmptyInstance: create)
+    ..pc<GConstructObject2>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject2.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject2._() : super();
+  factory GListOfConstructObject2({
+    $core.Iterable<GConstructObject2>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject2.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject2.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject2 clone() =>
+      GListOfConstructObject2()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject2 copyWith(
+          void Function(GListOfConstructObject2) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject2))
+          as GListOfConstructObject2; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject2 create() => GListOfConstructObject2._();
+  GListOfConstructObject2 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject2> createRepeated() =>
+      $pb.PbList<GListOfConstructObject2>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject2 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject2>(create);
+  static GListOfConstructObject2? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject2> get items => $_getList(0);
+}
+
+class GConstructObject3 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject3',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  GConstructObject3._() : super();
+  factory GConstructObject3({
+    $core.String? name,
+    $core.int? number,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    return _result;
+  }
+  factory GConstructObject3.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject3.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject3 clone() => GConstructObject3()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject3 copyWith(void Function(GConstructObject3) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject3))
+          as GConstructObject3; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject3 create() => GConstructObject3._();
+  GConstructObject3 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject3> createRepeated() =>
+      $pb.PbList<GConstructObject3>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject3 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject3>(create);
+  static GConstructObject3? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get number => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set number($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumber() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumber() => clearField(2);
+}
+
+class GListOfConstructObject3 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject3',
+      createEmptyInstance: create)
+    ..pc<GConstructObject3>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject3.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject3._() : super();
+  factory GListOfConstructObject3({
+    $core.Iterable<GConstructObject3>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject3.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject3.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject3 clone() =>
+      GListOfConstructObject3()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject3 copyWith(
+          void Function(GListOfConstructObject3) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject3))
+          as GListOfConstructObject3; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject3 create() => GListOfConstructObject3._();
+  GListOfConstructObject3 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject3> createRepeated() =>
+      $pb.PbList<GListOfConstructObject3>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject3 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject3>(create);
+  static GListOfConstructObject3? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject3> get items => $_getList(0);
+}
+
+class GConstructObject4 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject4',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  GConstructObject4._() : super();
+  factory GConstructObject4({
+    $core.String? name,
+    $core.int? number,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    return _result;
+  }
+  factory GConstructObject4.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject4.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject4 clone() => GConstructObject4()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject4 copyWith(void Function(GConstructObject4) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject4))
+          as GConstructObject4; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject4 create() => GConstructObject4._();
+  GConstructObject4 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject4> createRepeated() =>
+      $pb.PbList<GConstructObject4>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject4 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject4>(create);
+  static GConstructObject4? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get number => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set number($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumber() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumber() => clearField(2);
+}
+
+class GListOfConstructObject4 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject4',
+      createEmptyInstance: create)
+    ..pc<GConstructObject4>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject4.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject4._() : super();
+  factory GListOfConstructObject4({
+    $core.Iterable<GConstructObject4>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject4.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject4.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject4 clone() =>
+      GListOfConstructObject4()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject4 copyWith(
+          void Function(GListOfConstructObject4) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject4))
+          as GListOfConstructObject4; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject4 create() => GListOfConstructObject4._();
+  GListOfConstructObject4 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject4> createRepeated() =>
+      $pb.PbList<GListOfConstructObject4>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject4 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject4>(create);
+  static GListOfConstructObject4? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject4> get items => $_getList(0);
+}
+
+class GConstructObject5 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject5',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..a<$core.int>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..hasRequiredFields = false;
+
+  GConstructObject5._() : super();
+  factory GConstructObject5({
+    $core.String? name,
+    $core.int? number,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    return _result;
+  }
+  factory GConstructObject5.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject5.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject5 clone() => GConstructObject5()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject5 copyWith(void Function(GConstructObject5) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject5))
+          as GConstructObject5; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject5 create() => GConstructObject5._();
+  GConstructObject5 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject5> createRepeated() =>
+      $pb.PbList<GConstructObject5>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject5 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject5>(create);
+  static GConstructObject5? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.int get number => $_getIZ(1);
+  @$pb.TagNumber(2)
+  set number($core.int v) {
+    $_setSignedInt32(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumber() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumber() => clearField(2);
+}
+
+class GListOfConstructObject5 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject5',
+      createEmptyInstance: create)
+    ..pc<GConstructObject5>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject5.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject5._() : super();
+  factory GListOfConstructObject5({
+    $core.Iterable<GConstructObject5>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject5.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject5.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject5 clone() =>
+      GListOfConstructObject5()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject5 copyWith(
+          void Function(GListOfConstructObject5) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject5))
+          as GListOfConstructObject5; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject5 create() => GListOfConstructObject5._();
+  GListOfConstructObject5 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject5> createRepeated() =>
+      $pb.PbList<GListOfConstructObject5>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject5 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject5>(create);
+  static GListOfConstructObject5? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject5> get items => $_getList(0);
+}
+
+class GConstructObject6 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject6',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'nameHasValue',
+        protoName: 'nameHasValue')
+    ..a<$core.int>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..aOB(
+        4,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'numberHasValue',
+        protoName: 'numberHasValue')
+    ..hasRequiredFields = false;
+
+  GConstructObject6._() : super();
+  factory GConstructObject6({
+    $core.String? name,
+    $core.bool? nameHasValue,
+    $core.int? number,
+    $core.bool? numberHasValue,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (nameHasValue != null) {
+      _result.nameHasValue = nameHasValue;
+    }
+    if (number != null) {
+      _result.number = number;
+    }
+    if (numberHasValue != null) {
+      _result.numberHasValue = numberHasValue;
+    }
+    return _result;
+  }
+  factory GConstructObject6.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject6.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject6 clone() => GConstructObject6()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject6 copyWith(void Function(GConstructObject6) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject6))
+          as GConstructObject6; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject6 create() => GConstructObject6._();
+  GConstructObject6 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject6> createRepeated() =>
+      $pb.PbList<GConstructObject6>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject6 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject6>(create);
+  static GConstructObject6? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get nameHasValue => $_getBF(1);
+  @$pb.TagNumber(2)
+  set nameHasValue($core.bool v) {
+    $_setBool(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNameHasValue() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNameHasValue() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.int get number => $_getIZ(2);
+  @$pb.TagNumber(3)
+  set number($core.int v) {
+    $_setSignedInt32(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasNumber() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearNumber() => clearField(3);
+
+  @$pb.TagNumber(4)
+  $core.bool get numberHasValue => $_getBF(3);
+  @$pb.TagNumber(4)
+  set numberHasValue($core.bool v) {
+    $_setBool(3, v);
+  }
+
+  @$pb.TagNumber(4)
+  $core.bool hasNumberHasValue() => $_has(3);
+  @$pb.TagNumber(4)
+  void clearNumberHasValue() => clearField(4);
+}
+
+class GListOfConstructObject6 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject6',
+      createEmptyInstance: create)
+    ..pc<GConstructObject6>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject6.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject6._() : super();
+  factory GListOfConstructObject6({
+    $core.Iterable<GConstructObject6>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject6.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject6.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject6 clone() =>
+      GListOfConstructObject6()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject6 copyWith(
+          void Function(GListOfConstructObject6) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject6))
+          as GListOfConstructObject6; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject6 create() => GListOfConstructObject6._();
+  GListOfConstructObject6 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject6> createRepeated() =>
+      $pb.PbList<GListOfConstructObject6>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject6 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject6>(create);
+  static GListOfConstructObject6? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject6> get items => $_getList(0);
+}
+
+class GConstructObject7 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject7',
+      createEmptyInstance: create)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'numberHasValue',
+        protoName: 'numberHasValue')
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..hasRequiredFields = false;
+
+  GConstructObject7._() : super();
+  factory GConstructObject7({
+    $core.int? number,
+    $core.bool? numberHasValue,
+    $core.String? name,
+  }) {
+    final _result = create();
+    if (number != null) {
+      _result.number = number;
+    }
+    if (numberHasValue != null) {
+      _result.numberHasValue = numberHasValue;
+    }
+    if (name != null) {
+      _result.name = name;
+    }
+    return _result;
+  }
+  factory GConstructObject7.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject7.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject7 clone() => GConstructObject7()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject7 copyWith(void Function(GConstructObject7) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject7))
+          as GConstructObject7; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject7 create() => GConstructObject7._();
+  GConstructObject7 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject7> createRepeated() =>
+      $pb.PbList<GConstructObject7>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject7 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject7>(create);
+  static GConstructObject7? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get number => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set number($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasNumber() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNumber() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get numberHasValue => $_getBF(1);
+  @$pb.TagNumber(2)
+  set numberHasValue($core.bool v) {
+    $_setBool(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumberHasValue() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumberHasValue() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get name => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set name($core.String v) {
+    $_setString(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasName() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearName() => clearField(3);
+}
+
+class GListOfConstructObject7 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject7',
+      createEmptyInstance: create)
+    ..pc<GConstructObject7>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject7.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject7._() : super();
+  factory GListOfConstructObject7({
+    $core.Iterable<GConstructObject7>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject7.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject7.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject7 clone() =>
+      GListOfConstructObject7()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject7 copyWith(
+          void Function(GListOfConstructObject7) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject7))
+          as GListOfConstructObject7; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject7 create() => GListOfConstructObject7._();
+  GListOfConstructObject7 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject7> createRepeated() =>
+      $pb.PbList<GListOfConstructObject7>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject7 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject7>(create);
+  static GListOfConstructObject7? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject7> get items => $_getList(0);
+}
+
+class GConstructObject8 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GConstructObject8',
+      createEmptyInstance: create)
+    ..a<$core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'number',
+        $pb.PbFieldType.O3)
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'numberHasValue',
+        protoName: 'numberHasValue')
+    ..aOS(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..hasRequiredFields = false;
+
+  GConstructObject8._() : super();
+  factory GConstructObject8({
+    $core.int? number,
+    $core.bool? numberHasValue,
+    $core.String? name,
+  }) {
+    final _result = create();
+    if (number != null) {
+      _result.number = number;
+    }
+    if (numberHasValue != null) {
+      _result.numberHasValue = numberHasValue;
+    }
+    if (name != null) {
+      _result.name = name;
+    }
+    return _result;
+  }
+  factory GConstructObject8.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GConstructObject8.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GConstructObject8 clone() => GConstructObject8()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GConstructObject8 copyWith(void Function(GConstructObject8) updates) =>
+      super.copyWith((message) => updates(message as GConstructObject8))
+          as GConstructObject8; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject8 create() => GConstructObject8._();
+  GConstructObject8 createEmptyInstance() => create();
+  static $pb.PbList<GConstructObject8> createRepeated() =>
+      $pb.PbList<GConstructObject8>();
+  @$core.pragma('dart2js:noInline')
+  static GConstructObject8 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GConstructObject8>(create);
+  static GConstructObject8? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.int get number => $_getIZ(0);
+  @$pb.TagNumber(1)
+  set number($core.int v) {
+    $_setSignedInt32(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasNumber() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearNumber() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get numberHasValue => $_getBF(1);
+  @$pb.TagNumber(2)
+  set numberHasValue($core.bool v) {
+    $_setBool(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasNumberHasValue() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearNumberHasValue() => clearField(2);
+
+  @$pb.TagNumber(3)
+  $core.String get name => $_getSZ(2);
+  @$pb.TagNumber(3)
+  set name($core.String v) {
+    $_setString(2, v);
+  }
+
+  @$pb.TagNumber(3)
+  $core.bool hasName() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearName() => clearField(3);
+}
+
+class GListOfConstructObject8 extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfConstructObject8',
+      createEmptyInstance: create)
+    ..pc<GConstructObject8>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GConstructObject8.create)
+    ..hasRequiredFields = false;
+
+  GListOfConstructObject8._() : super();
+  factory GListOfConstructObject8({
+    $core.Iterable<GConstructObject8>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfConstructObject8.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfConstructObject8.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject8 clone() =>
+      GListOfConstructObject8()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfConstructObject8 copyWith(
+          void Function(GListOfConstructObject8) updates) =>
+      super.copyWith((message) => updates(message as GListOfConstructObject8))
+          as GListOfConstructObject8; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject8 create() => GListOfConstructObject8._();
+  GListOfConstructObject8 createEmptyInstance() => create();
+  static $pb.PbList<GListOfConstructObject8> createRepeated() =>
+      $pb.PbList<GListOfConstructObject8>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfConstructObject8 getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfConstructObject8>(create);
+  static GListOfConstructObject8? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GConstructObject8> get items => $_getList(0);
+}

--- a/proto_mapper/test/lib/grpc/constructors_host.pbenum.dart
+++ b/proto_mapper/test/lib/grpc/constructors_host.pbenum.dart
@@ -1,0 +1,6 @@
+///
+//  Generated code. Do not modify.
+//  source: constructors_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/proto_mapper/test/lib/grpc/constructors_host.pbjson.dart
+++ b/proto_mapper/test/lib/grpc/constructors_host.pbjson.dart
@@ -1,0 +1,263 @@
+///
+//  Generated code. Do not modify.
+//  source: constructors_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use gConstructObject1Descriptor instead')
+const GConstructObject1$json = {
+  '1': 'GConstructObject1',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'number', '3': 2, '4': 1, '5': 5, '10': 'number'},
+  ],
+};
+
+/// Descriptor for `GConstructObject1`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject1Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0MRISCgRuYW1lGAEgASgJUgRuYW1lEhYKBm51bWJlchgCIAEoBVIGbnVtYmVy');
+@$core.Deprecated('Use gListOfConstructObject1Descriptor instead')
+const GListOfConstructObject1$json = {
+  '1': 'GListOfConstructObject1',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject1',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject1`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject1Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0MRIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3QxUgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject2Descriptor instead')
+const GConstructObject2$json = {
+  '1': 'GConstructObject2',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'number', '3': 2, '4': 1, '5': 5, '10': 'number'},
+  ],
+};
+
+/// Descriptor for `GConstructObject2`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject2Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0MhISCgRuYW1lGAEgASgJUgRuYW1lEhYKBm51bWJlchgCIAEoBVIGbnVtYmVy');
+@$core.Deprecated('Use gListOfConstructObject2Descriptor instead')
+const GListOfConstructObject2$json = {
+  '1': 'GListOfConstructObject2',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject2',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject2`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject2Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0MhIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3QyUgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject3Descriptor instead')
+const GConstructObject3$json = {
+  '1': 'GConstructObject3',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'number', '3': 2, '4': 1, '5': 5, '10': 'number'},
+  ],
+};
+
+/// Descriptor for `GConstructObject3`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject3Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0MxISCgRuYW1lGAEgASgJUgRuYW1lEhYKBm51bWJlchgCIAEoBVIGbnVtYmVy');
+@$core.Deprecated('Use gListOfConstructObject3Descriptor instead')
+const GListOfConstructObject3$json = {
+  '1': 'GListOfConstructObject3',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject3',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject3`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject3Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0MxIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3QzUgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject4Descriptor instead')
+const GConstructObject4$json = {
+  '1': 'GConstructObject4',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'number', '3': 2, '4': 1, '5': 5, '10': 'number'},
+  ],
+};
+
+/// Descriptor for `GConstructObject4`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject4Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0NBISCgRuYW1lGAEgASgJUgRuYW1lEhYKBm51bWJlchgCIAEoBVIGbnVtYmVy');
+@$core.Deprecated('Use gListOfConstructObject4Descriptor instead')
+const GListOfConstructObject4$json = {
+  '1': 'GListOfConstructObject4',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject4',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject4`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject4Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0NBIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3Q0UgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject5Descriptor instead')
+const GConstructObject5$json = {
+  '1': 'GConstructObject5',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'number', '3': 2, '4': 1, '5': 5, '10': 'number'},
+  ],
+};
+
+/// Descriptor for `GConstructObject5`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject5Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0NRISCgRuYW1lGAEgASgJUgRuYW1lEhYKBm51bWJlchgCIAEoBVIGbnVtYmVy');
+@$core.Deprecated('Use gListOfConstructObject5Descriptor instead')
+const GListOfConstructObject5$json = {
+  '1': 'GListOfConstructObject5',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject5',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject5`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject5Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0NRIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3Q1UgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject6Descriptor instead')
+const GConstructObject6$json = {
+  '1': 'GConstructObject6',
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'nameHasValue', '3': 2, '4': 1, '5': 8, '10': 'nameHasValue'},
+    {'1': 'number', '3': 3, '4': 1, '5': 5, '10': 'number'},
+    {'1': 'numberHasValue', '3': 4, '4': 1, '5': 8, '10': 'numberHasValue'},
+  ],
+};
+
+/// Descriptor for `GConstructObject6`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject6Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0NhISCgRuYW1lGAEgASgJUgRuYW1lEiIKDG5hbWVIYXNWYWx1ZRgCIAEoCFIMbmFtZUhhc1ZhbHVlEhYKBm51bWJlchgDIAEoBVIGbnVtYmVyEiYKDm51bWJlckhhc1ZhbHVlGAQgASgIUg5udW1iZXJIYXNWYWx1ZQ==');
+@$core.Deprecated('Use gListOfConstructObject6Descriptor instead')
+const GListOfConstructObject6$json = {
+  '1': 'GListOfConstructObject6',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject6',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject6`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject6Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0NhIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3Q2UgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject7Descriptor instead')
+const GConstructObject7$json = {
+  '1': 'GConstructObject7',
+  '2': [
+    {'1': 'number', '3': 1, '4': 1, '5': 5, '10': 'number'},
+    {'1': 'numberHasValue', '3': 2, '4': 1, '5': 8, '10': 'numberHasValue'},
+    {'1': 'name', '3': 3, '4': 1, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `GConstructObject7`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject7Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0NxIWCgZudW1iZXIYASABKAVSBm51bWJlchImCg5udW1iZXJIYXNWYWx1ZRgCIAEoCFIObnVtYmVySGFzVmFsdWUSEgoEbmFtZRgDIAEoCVIEbmFtZQ==');
+@$core.Deprecated('Use gListOfConstructObject7Descriptor instead')
+const GListOfConstructObject7$json = {
+  '1': 'GListOfConstructObject7',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject7',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject7`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject7Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0NxIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3Q3UgVpdGVtcw==');
+@$core.Deprecated('Use gConstructObject8Descriptor instead')
+const GConstructObject8$json = {
+  '1': 'GConstructObject8',
+  '2': [
+    {'1': 'number', '3': 1, '4': 1, '5': 5, '10': 'number'},
+    {'1': 'numberHasValue', '3': 2, '4': 1, '5': 8, '10': 'numberHasValue'},
+    {'1': 'name', '3': 3, '4': 1, '5': 9, '10': 'name'},
+  ],
+};
+
+/// Descriptor for `GConstructObject8`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gConstructObject8Descriptor = $convert.base64Decode(
+    'ChFHQ29uc3RydWN0T2JqZWN0OBIWCgZudW1iZXIYASABKAVSBm51bWJlchImCg5udW1iZXJIYXNWYWx1ZRgCIAEoCFIObnVtYmVySGFzVmFsdWUSEgoEbmFtZRgDIAEoCVIEbmFtZQ==');
+@$core.Deprecated('Use gListOfConstructObject8Descriptor instead')
+const GListOfConstructObject8$json = {
+  '1': 'GListOfConstructObject8',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GConstructObject8',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfConstructObject8`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfConstructObject8Descriptor =
+    $convert.base64Decode(
+        'ChdHTGlzdE9mQ29uc3RydWN0T2JqZWN0OBIoCgVpdGVtcxgBIAMoCzISLkdDb25zdHJ1Y3RPYmplY3Q4UgVpdGVtcw==');

--- a/proto_mapper/test/lib/grpc/utensils.pb.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pb.dart
@@ -17,11 +17,26 @@ import 'appliance_type.pbenum.dart' as $6;
 export 'utensils.pbenum.dart';
 
 class GKnife extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GKnife', createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
-    ..e<GKnifeType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: GKnifeType.chefsKnife, valueOf: GKnifeType.valueOf, enumValues: GKnifeType.values)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GKnife',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..e<GKnifeType>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'type',
+        $pb.PbFieldType.OE,
+        defaultOrMaker: GKnifeType.chefsKnife,
+        valueOf: GKnifeType.valueOf,
+        enumValues: GKnifeType.values)
+    ..hasRequiredFields = false;
 
   GKnife._() : super();
   factory GKnife({
@@ -37,31 +52,39 @@ class GKnife extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GKnife.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GKnife.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GKnife.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GKnife.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GKnife clone() => GKnife()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GKnife copyWith(void Function(GKnife) updates) => super.copyWith((message) => updates(message as GKnife)) as GKnife; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GKnife copyWith(void Function(GKnife) updates) =>
+      super.copyWith((message) => updates(message as GKnife))
+          as GKnife; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GKnife create() => GKnife._();
   GKnife createEmptyInstance() => create();
   static $pb.PbList<GKnife> createRepeated() => $pb.PbList<GKnife>();
   @$core.pragma('dart2js:noInline')
-  static GKnife getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKnife>(create);
+  static GKnife getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKnife>(create);
   static GKnife? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -70,7 +93,10 @@ class GKnife extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   GKnifeType get type => $_getN(1);
   @$pb.TagNumber(2)
-  set type(GKnifeType v) { setField(2, v); }
+  set type(GKnifeType v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasType() => $_has(1);
   @$pb.TagNumber(2)
@@ -78,10 +104,19 @@ class GKnife extends $pb.GeneratedMessage {
 }
 
 class GListOfKnife extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfKnife', createEmptyInstance: create)
-    ..pc<GKnife>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GKnife.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfKnife',
+      createEmptyInstance: create)
+    ..pc<GKnife>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GKnife.create)
+    ..hasRequiredFields = false;
 
   GListOfKnife._() : super();
   factory GListOfKnife({
@@ -93,25 +128,31 @@ class GListOfKnife extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GListOfKnife.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GListOfKnife.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GListOfKnife.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfKnife.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GListOfKnife clone() => GListOfKnife()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GListOfKnife copyWith(void Function(GListOfKnife) updates) => super.copyWith((message) => updates(message as GListOfKnife)) as GListOfKnife; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfKnife copyWith(void Function(GListOfKnife) updates) =>
+      super.copyWith((message) => updates(message as GListOfKnife))
+          as GListOfKnife; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GListOfKnife create() => GListOfKnife._();
   GListOfKnife createEmptyInstance() => create();
-  static $pb.PbList<GListOfKnife> createRepeated() => $pb.PbList<GListOfKnife>();
+  static $pb.PbList<GListOfKnife> createRepeated() =>
+      $pb.PbList<GListOfKnife>();
   @$core.pragma('dart2js:noInline')
-  static GListOfKnife getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfKnife>(create);
+  static GListOfKnife getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfKnife>(create);
   static GListOfKnife? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -119,11 +160,23 @@ class GListOfKnife extends $pb.GeneratedMessage {
 }
 
 class GGarlicPress extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GGarlicPress', createEmptyInstance: create)
-    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
-    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'machineWashable', protoName: 'machineWashable')
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GGarlicPress',
+      createEmptyInstance: create)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'name')
+    ..aOB(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'machineWashable',
+        protoName: 'machineWashable')
+    ..hasRequiredFields = false;
 
   GGarlicPress._() : super();
   factory GGarlicPress({
@@ -139,31 +192,40 @@ class GGarlicPress extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GGarlicPress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GGarlicPress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GGarlicPress.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GGarlicPress.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GGarlicPress clone() => GGarlicPress()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GGarlicPress copyWith(void Function(GGarlicPress) updates) => super.copyWith((message) => updates(message as GGarlicPress)) as GGarlicPress; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GGarlicPress copyWith(void Function(GGarlicPress) updates) =>
+      super.copyWith((message) => updates(message as GGarlicPress))
+          as GGarlicPress; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GGarlicPress create() => GGarlicPress._();
   GGarlicPress createEmptyInstance() => create();
-  static $pb.PbList<GGarlicPress> createRepeated() => $pb.PbList<GGarlicPress>();
+  static $pb.PbList<GGarlicPress> createRepeated() =>
+      $pb.PbList<GGarlicPress>();
   @$core.pragma('dart2js:noInline')
-  static GGarlicPress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GGarlicPress>(create);
+  static GGarlicPress getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GGarlicPress>(create);
   static GGarlicPress? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.String get name => $_getSZ(0);
   @$pb.TagNumber(1)
-  set name($core.String v) { $_setString(0, v); }
+  set name($core.String v) {
+    $_setString(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasName() => $_has(0);
   @$pb.TagNumber(1)
@@ -172,7 +234,10 @@ class GGarlicPress extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   $core.bool get machineWashable => $_getBF(1);
   @$pb.TagNumber(2)
-  set machineWashable($core.bool v) { $_setBool(1, v); }
+  set machineWashable($core.bool v) {
+    $_setBool(1, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasMachineWashable() => $_has(1);
   @$pb.TagNumber(2)
@@ -180,10 +245,19 @@ class GGarlicPress extends $pb.GeneratedMessage {
 }
 
 class GListOfGarlicPress extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfGarlicPress', createEmptyInstance: create)
-    ..pc<GGarlicPress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GGarlicPress.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfGarlicPress',
+      createEmptyInstance: create)
+    ..pc<GGarlicPress>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GGarlicPress.create)
+    ..hasRequiredFields = false;
 
   GListOfGarlicPress._() : super();
   factory GListOfGarlicPress({
@@ -195,25 +269,31 @@ class GListOfGarlicPress extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GListOfGarlicPress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GListOfGarlicPress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GListOfGarlicPress.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfGarlicPress.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GListOfGarlicPress clone() => GListOfGarlicPress()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GListOfGarlicPress copyWith(void Function(GListOfGarlicPress) updates) => super.copyWith((message) => updates(message as GListOfGarlicPress)) as GListOfGarlicPress; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfGarlicPress copyWith(void Function(GListOfGarlicPress) updates) =>
+      super.copyWith((message) => updates(message as GListOfGarlicPress))
+          as GListOfGarlicPress; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GListOfGarlicPress create() => GListOfGarlicPress._();
   GListOfGarlicPress createEmptyInstance() => create();
-  static $pb.PbList<GListOfGarlicPress> createRepeated() => $pb.PbList<GListOfGarlicPress>();
+  static $pb.PbList<GListOfGarlicPress> createRepeated() =>
+      $pb.PbList<GListOfGarlicPress>();
   @$core.pragma('dart2js:noInline')
-  static GListOfGarlicPress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfGarlicPress>(create);
+  static GListOfGarlicPress getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfGarlicPress>(create);
   static GListOfGarlicPress? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -221,11 +301,30 @@ class GListOfGarlicPress extends $pb.GeneratedMessage {
 }
 
 class GKitchen extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GKitchen', createEmptyInstance: create)
-    ..pc<$0.GRecipe>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipeList', $pb.PbFieldType.PM, protoName: 'recipeList', subBuilder: $0.GRecipe.create)
-    ..m<$core.String, $0.GRecipe>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipeMap', protoName: 'recipeMap', entryClassName: 'GKitchen.RecipeMapEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: $0.GRecipe.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GKitchen',
+      createEmptyInstance: create)
+    ..pc<$0.GRecipe>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'recipeList',
+        $pb.PbFieldType.PM,
+        protoName: 'recipeList',
+        subBuilder: $0.GRecipe.create)
+    ..m<$core.String, $0.GRecipe>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'recipeMap',
+        protoName: 'recipeMap',
+        entryClassName: 'GKitchen.RecipeMapEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: $0.GRecipe.create)
+    ..hasRequiredFields = false;
 
   GKitchen._() : super();
   factory GKitchen({
@@ -241,25 +340,30 @@ class GKitchen extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GKitchen.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GKitchen.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GKitchen.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GKitchen.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GKitchen clone() => GKitchen()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GKitchen copyWith(void Function(GKitchen) updates) => super.copyWith((message) => updates(message as GKitchen)) as GKitchen; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GKitchen copyWith(void Function(GKitchen) updates) =>
+      super.copyWith((message) => updates(message as GKitchen))
+          as GKitchen; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GKitchen create() => GKitchen._();
   GKitchen createEmptyInstance() => create();
   static $pb.PbList<GKitchen> createRepeated() => $pb.PbList<GKitchen>();
   @$core.pragma('dart2js:noInline')
-  static GKitchen getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKitchen>(create);
+  static GKitchen getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKitchen>(create);
   static GKitchen? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -270,10 +374,19 @@ class GKitchen extends $pb.GeneratedMessage {
 }
 
 class GListOfKitchen extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfKitchen', createEmptyInstance: create)
-    ..pc<GKitchen>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GKitchen.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfKitchen',
+      createEmptyInstance: create)
+    ..pc<GKitchen>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GKitchen.create)
+    ..hasRequiredFields = false;
 
   GListOfKitchen._() : super();
   factory GListOfKitchen({
@@ -285,25 +398,31 @@ class GListOfKitchen extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GListOfKitchen.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GListOfKitchen.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GListOfKitchen.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfKitchen.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GListOfKitchen clone() => GListOfKitchen()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GListOfKitchen copyWith(void Function(GListOfKitchen) updates) => super.copyWith((message) => updates(message as GListOfKitchen)) as GListOfKitchen; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfKitchen copyWith(void Function(GListOfKitchen) updates) =>
+      super.copyWith((message) => updates(message as GListOfKitchen))
+          as GListOfKitchen; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GListOfKitchen create() => GListOfKitchen._();
   GListOfKitchen createEmptyInstance() => create();
-  static $pb.PbList<GListOfKitchen> createRepeated() => $pb.PbList<GListOfKitchen>();
+  static $pb.PbList<GListOfKitchen> createRepeated() =>
+      $pb.PbList<GListOfKitchen>();
   @$core.pragma('dart2js:noInline')
-  static GListOfKitchen getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfKitchen>(create);
+  static GListOfKitchen getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfKitchen>(create);
   static GListOfKitchen? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -311,12 +430,36 @@ class GListOfKitchen extends $pb.GeneratedMessage {
 }
 
 class GChef extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GChef', createEmptyInstance: create)
-    ..aOM<$0.GRecipe>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteRecipe', protoName: 'favoriteRecipe', subBuilder: $0.GRecipe.create)
-    ..aOM<GKnife>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteKnife', protoName: 'favoriteKnife', subBuilder: GKnife.create)
-    ..e<$6.GApplianceType>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteApplianceType', $pb.PbFieldType.OE, protoName: 'favoriteApplianceType', defaultOrMaker: $6.GApplianceType.heat, valueOf: $6.GApplianceType.valueOf, enumValues: $6.GApplianceType.values)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GChef',
+      createEmptyInstance: create)
+    ..aOM<$0.GRecipe>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'favoriteRecipe',
+        protoName: 'favoriteRecipe',
+        subBuilder: $0.GRecipe.create)
+    ..aOM<GKnife>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'favoriteKnife',
+        protoName: 'favoriteKnife',
+        subBuilder: GKnife.create)
+    ..e<$6.GApplianceType>(
+        3,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'favoriteApplianceType',
+        $pb.PbFieldType.OE,
+        protoName: 'favoriteApplianceType',
+        defaultOrMaker: $6.GApplianceType.heat,
+        valueOf: $6.GApplianceType.valueOf,
+        enumValues: $6.GApplianceType.values)
+    ..hasRequiredFields = false;
 
   GChef._() : super();
   factory GChef({
@@ -336,31 +479,39 @@ class GChef extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GChef.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GChef.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GChef.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GChef.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GChef clone() => GChef()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GChef copyWith(void Function(GChef) updates) => super.copyWith((message) => updates(message as GChef)) as GChef; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GChef copyWith(void Function(GChef) updates) =>
+      super.copyWith((message) => updates(message as GChef))
+          as GChef; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GChef create() => GChef._();
   GChef createEmptyInstance() => create();
   static $pb.PbList<GChef> createRepeated() => $pb.PbList<GChef>();
   @$core.pragma('dart2js:noInline')
-  static GChef getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GChef>(create);
+  static GChef getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GChef>(create);
   static GChef? _defaultInstance;
 
   @$pb.TagNumber(1)
   $0.GRecipe get favoriteRecipe => $_getN(0);
   @$pb.TagNumber(1)
-  set favoriteRecipe($0.GRecipe v) { setField(1, v); }
+  set favoriteRecipe($0.GRecipe v) {
+    setField(1, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasFavoriteRecipe() => $_has(0);
   @$pb.TagNumber(1)
@@ -371,7 +522,10 @@ class GChef extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   GKnife get favoriteKnife => $_getN(1);
   @$pb.TagNumber(2)
-  set favoriteKnife(GKnife v) { setField(2, v); }
+  set favoriteKnife(GKnife v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasFavoriteKnife() => $_has(1);
   @$pb.TagNumber(2)
@@ -382,7 +536,10 @@ class GChef extends $pb.GeneratedMessage {
   @$pb.TagNumber(3)
   $6.GApplianceType get favoriteApplianceType => $_getN(2);
   @$pb.TagNumber(3)
-  set favoriteApplianceType($6.GApplianceType v) { setField(3, v); }
+  set favoriteApplianceType($6.GApplianceType v) {
+    setField(3, v);
+  }
+
   @$pb.TagNumber(3)
   $core.bool hasFavoriteApplianceType() => $_has(2);
   @$pb.TagNumber(3)
@@ -390,10 +547,19 @@ class GChef extends $pb.GeneratedMessage {
 }
 
 class GListOfChef extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfChef', createEmptyInstance: create)
-    ..pc<GChef>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GChef.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfChef',
+      createEmptyInstance: create)
+    ..pc<GChef>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GChef.create)
+    ..hasRequiredFields = false;
 
   GListOfChef._() : super();
   factory GListOfChef({
@@ -405,25 +571,30 @@ class GListOfChef extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GListOfChef.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GListOfChef.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GListOfChef.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfChef.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GListOfChef clone() => GListOfChef()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GListOfChef copyWith(void Function(GListOfChef) updates) => super.copyWith((message) => updates(message as GListOfChef)) as GListOfChef; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfChef copyWith(void Function(GListOfChef) updates) =>
+      super.copyWith((message) => updates(message as GListOfChef))
+          as GListOfChef; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GListOfChef create() => GListOfChef._();
   GListOfChef createEmptyInstance() => create();
   static $pb.PbList<GListOfChef> createRepeated() => $pb.PbList<GListOfChef>();
   @$core.pragma('dart2js:noInline')
-  static GListOfChef getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfChef>(create);
+  static GListOfChef getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfChef>(create);
   static GListOfChef? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -431,11 +602,31 @@ class GListOfChef extends $pb.GeneratedMessage {
 }
 
 class GInventory extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GInventory', createEmptyInstance: create)
-    ..m<$core.String, $core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'numberOfThings', protoName: 'numberOfThings', entryClassName: 'GInventory.NumberOfThingsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.O3)
-    ..m<$core.String, $0.GRecipe>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipesByName', protoName: 'recipesByName', entryClassName: 'GInventory.RecipesByNameEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: $0.GRecipe.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GInventory',
+      createEmptyInstance: create)
+    ..m<$core.String, $core.int>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'numberOfThings',
+        protoName: 'numberOfThings',
+        entryClassName: 'GInventory.NumberOfThingsEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.O3)
+    ..m<$core.String, $0.GRecipe>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'recipesByName',
+        protoName: 'recipesByName',
+        entryClassName: 'GInventory.RecipesByNameEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: $0.GRecipe.create)
+    ..hasRequiredFields = false;
 
   GInventory._() : super();
   factory GInventory({
@@ -451,25 +642,30 @@ class GInventory extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GInventory.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GInventory.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GInventory.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GInventory.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GInventory clone() => GInventory()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GInventory copyWith(void Function(GInventory) updates) => super.copyWith((message) => updates(message as GInventory)) as GInventory; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GInventory copyWith(void Function(GInventory) updates) =>
+      super.copyWith((message) => updates(message as GInventory))
+          as GInventory; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GInventory create() => GInventory._();
   GInventory createEmptyInstance() => create();
   static $pb.PbList<GInventory> createRepeated() => $pb.PbList<GInventory>();
   @$core.pragma('dart2js:noInline')
-  static GInventory getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GInventory>(create);
+  static GInventory getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GInventory>(create);
   static GInventory? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -480,10 +676,19 @@ class GInventory extends $pb.GeneratedMessage {
 }
 
 class GListOfInventory extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfInventory', createEmptyInstance: create)
-    ..pc<GInventory>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GInventory.create)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfInventory',
+      createEmptyInstance: create)
+    ..pc<GInventory>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GInventory.create)
+    ..hasRequiredFields = false;
 
   GListOfInventory._() : super();
   factory GListOfInventory({
@@ -495,25 +700,31 @@ class GListOfInventory extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory GListOfInventory.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory GListOfInventory.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory GListOfInventory.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfInventory.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   GListOfInventory clone() => GListOfInventory()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  GListOfInventory copyWith(void Function(GListOfInventory) updates) => super.copyWith((message) => updates(message as GListOfInventory)) as GListOfInventory; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfInventory copyWith(void Function(GListOfInventory) updates) =>
+      super.copyWith((message) => updates(message as GListOfInventory))
+          as GListOfInventory; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static GListOfInventory create() => GListOfInventory._();
   GListOfInventory createEmptyInstance() => create();
-  static $pb.PbList<GListOfInventory> createRepeated() => $pb.PbList<GListOfInventory>();
+  static $pb.PbList<GListOfInventory> createRepeated() =>
+      $pb.PbList<GListOfInventory>();
   @$core.pragma('dart2js:noInline')
-  static GListOfInventory getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfInventory>(create);
+  static GListOfInventory getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfInventory>(create);
   static GListOfInventory? _defaultInstance;
 
   @$pb.TagNumber(1)
@@ -521,11 +732,27 @@ class GListOfInventory extends $pb.GeneratedMessage {
 }
 
 class NullableGKnifeType extends $pb.GeneratedMessage {
-  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NullableGKnifeType', createEmptyInstance: create)
-    ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hasValue', protoName: 'hasValue')
-    ..e<GKnifeType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OE, defaultOrMaker: GKnifeType.chefsKnife, valueOf: GKnifeType.valueOf, enumValues: GKnifeType.values)
-    ..hasRequiredFields = false
-  ;
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'NullableGKnifeType',
+      createEmptyInstance: create)
+    ..aOB(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'hasValue',
+        protoName: 'hasValue')
+    ..e<GKnifeType>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'value',
+        $pb.PbFieldType.OE,
+        defaultOrMaker: GKnifeType.chefsKnife,
+        valueOf: GKnifeType.valueOf,
+        enumValues: GKnifeType.values)
+    ..hasRequiredFields = false;
 
   NullableGKnifeType._() : super();
   factory NullableGKnifeType({
@@ -541,31 +768,40 @@ class NullableGKnifeType extends $pb.GeneratedMessage {
     }
     return _result;
   }
-  factory NullableGKnifeType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
-  factory NullableGKnifeType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
-  'Will be removed in next major version')
+  factory NullableGKnifeType.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory NullableGKnifeType.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
   NullableGKnifeType clone() => NullableGKnifeType()..mergeFromMessage(this);
-  @$core.Deprecated(
-  'Using this can add significant overhead to your binary. '
-  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
-  'Will be removed in next major version')
-  NullableGKnifeType copyWith(void Function(NullableGKnifeType) updates) => super.copyWith((message) => updates(message as NullableGKnifeType)) as NullableGKnifeType; // ignore: deprecated_member_use
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  NullableGKnifeType copyWith(void Function(NullableGKnifeType) updates) =>
+      super.copyWith((message) => updates(message as NullableGKnifeType))
+          as NullableGKnifeType; // ignore: deprecated_member_use
   $pb.BuilderInfo get info_ => _i;
   @$core.pragma('dart2js:noInline')
   static NullableGKnifeType create() => NullableGKnifeType._();
   NullableGKnifeType createEmptyInstance() => create();
-  static $pb.PbList<NullableGKnifeType> createRepeated() => $pb.PbList<NullableGKnifeType>();
+  static $pb.PbList<NullableGKnifeType> createRepeated() =>
+      $pb.PbList<NullableGKnifeType>();
   @$core.pragma('dart2js:noInline')
-  static NullableGKnifeType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NullableGKnifeType>(create);
+  static NullableGKnifeType getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<NullableGKnifeType>(create);
   static NullableGKnifeType? _defaultInstance;
 
   @$pb.TagNumber(1)
   $core.bool get hasValue => $_getBF(0);
   @$pb.TagNumber(1)
-  set hasValue($core.bool v) { $_setBool(0, v); }
+  set hasValue($core.bool v) {
+    $_setBool(0, v);
+  }
+
   @$pb.TagNumber(1)
   $core.bool hasHasValue() => $_has(0);
   @$pb.TagNumber(1)
@@ -574,10 +810,12 @@ class NullableGKnifeType extends $pb.GeneratedMessage {
   @$pb.TagNumber(2)
   GKnifeType get value_2 => $_getN(1);
   @$pb.TagNumber(2)
-  set value_2(GKnifeType v) { setField(2, v); }
+  set value_2(GKnifeType v) {
+    setField(2, v);
+  }
+
   @$pb.TagNumber(2)
   $core.bool hasValue_2() => $_has(1);
   @$pb.TagNumber(2)
   void clearValue_2() => clearField(2);
 }
-

--- a/proto_mapper/test/lib/grpc/utensils.pb.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pb.dart
@@ -1,0 +1,583 @@
+///
+//  Generated code. Do not modify.
+//  source: utensils.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'recipe.pb.dart' as $0;
+
+import 'utensils.pbenum.dart';
+import 'appliance_type.pbenum.dart' as $6;
+
+export 'utensils.pbenum.dart';
+
+class GKnife extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GKnife', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..e<GKnifeType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'type', $pb.PbFieldType.OE, defaultOrMaker: GKnifeType.chefsKnife, valueOf: GKnifeType.valueOf, enumValues: GKnifeType.values)
+    ..hasRequiredFields = false
+  ;
+
+  GKnife._() : super();
+  factory GKnife({
+    $core.String? name,
+    GKnifeType? type,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (type != null) {
+      _result.type = type;
+    }
+    return _result;
+  }
+  factory GKnife.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GKnife.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GKnife clone() => GKnife()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GKnife copyWith(void Function(GKnife) updates) => super.copyWith((message) => updates(message as GKnife)) as GKnife; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GKnife create() => GKnife._();
+  GKnife createEmptyInstance() => create();
+  static $pb.PbList<GKnife> createRepeated() => $pb.PbList<GKnife>();
+  @$core.pragma('dart2js:noInline')
+  static GKnife getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKnife>(create);
+  static GKnife? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  GKnifeType get type => $_getN(1);
+  @$pb.TagNumber(2)
+  set type(GKnifeType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasType() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearType() => clearField(2);
+}
+
+class GListOfKnife extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfKnife', createEmptyInstance: create)
+    ..pc<GKnife>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GKnife.create)
+    ..hasRequiredFields = false
+  ;
+
+  GListOfKnife._() : super();
+  factory GListOfKnife({
+    $core.Iterable<GKnife>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfKnife.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GListOfKnife.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GListOfKnife clone() => GListOfKnife()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GListOfKnife copyWith(void Function(GListOfKnife) updates) => super.copyWith((message) => updates(message as GListOfKnife)) as GListOfKnife; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfKnife create() => GListOfKnife._();
+  GListOfKnife createEmptyInstance() => create();
+  static $pb.PbList<GListOfKnife> createRepeated() => $pb.PbList<GListOfKnife>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfKnife getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfKnife>(create);
+  static GListOfKnife? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GKnife> get items => $_getList(0);
+}
+
+class GGarlicPress extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GGarlicPress', createEmptyInstance: create)
+    ..aOS(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'name')
+    ..aOB(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'machineWashable', protoName: 'machineWashable')
+    ..hasRequiredFields = false
+  ;
+
+  GGarlicPress._() : super();
+  factory GGarlicPress({
+    $core.String? name,
+    $core.bool? machineWashable,
+  }) {
+    final _result = create();
+    if (name != null) {
+      _result.name = name;
+    }
+    if (machineWashable != null) {
+      _result.machineWashable = machineWashable;
+    }
+    return _result;
+  }
+  factory GGarlicPress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GGarlicPress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GGarlicPress clone() => GGarlicPress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GGarlicPress copyWith(void Function(GGarlicPress) updates) => super.copyWith((message) => updates(message as GGarlicPress)) as GGarlicPress; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GGarlicPress create() => GGarlicPress._();
+  GGarlicPress createEmptyInstance() => create();
+  static $pb.PbList<GGarlicPress> createRepeated() => $pb.PbList<GGarlicPress>();
+  @$core.pragma('dart2js:noInline')
+  static GGarlicPress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GGarlicPress>(create);
+  static GGarlicPress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get name => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set name($core.String v) { $_setString(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasName() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearName() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.bool get machineWashable => $_getBF(1);
+  @$pb.TagNumber(2)
+  set machineWashable($core.bool v) { $_setBool(1, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasMachineWashable() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearMachineWashable() => clearField(2);
+}
+
+class GListOfGarlicPress extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfGarlicPress', createEmptyInstance: create)
+    ..pc<GGarlicPress>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GGarlicPress.create)
+    ..hasRequiredFields = false
+  ;
+
+  GListOfGarlicPress._() : super();
+  factory GListOfGarlicPress({
+    $core.Iterable<GGarlicPress>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfGarlicPress.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GListOfGarlicPress.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GListOfGarlicPress clone() => GListOfGarlicPress()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GListOfGarlicPress copyWith(void Function(GListOfGarlicPress) updates) => super.copyWith((message) => updates(message as GListOfGarlicPress)) as GListOfGarlicPress; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfGarlicPress create() => GListOfGarlicPress._();
+  GListOfGarlicPress createEmptyInstance() => create();
+  static $pb.PbList<GListOfGarlicPress> createRepeated() => $pb.PbList<GListOfGarlicPress>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfGarlicPress getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfGarlicPress>(create);
+  static GListOfGarlicPress? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GGarlicPress> get items => $_getList(0);
+}
+
+class GKitchen extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GKitchen', createEmptyInstance: create)
+    ..pc<$0.GRecipe>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipeList', $pb.PbFieldType.PM, protoName: 'recipeList', subBuilder: $0.GRecipe.create)
+    ..m<$core.String, $0.GRecipe>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipeMap', protoName: 'recipeMap', entryClassName: 'GKitchen.RecipeMapEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: $0.GRecipe.create)
+    ..hasRequiredFields = false
+  ;
+
+  GKitchen._() : super();
+  factory GKitchen({
+    $core.Iterable<$0.GRecipe>? recipeList,
+    $core.Map<$core.String, $0.GRecipe>? recipeMap,
+  }) {
+    final _result = create();
+    if (recipeList != null) {
+      _result.recipeList.addAll(recipeList);
+    }
+    if (recipeMap != null) {
+      _result.recipeMap.addAll(recipeMap);
+    }
+    return _result;
+  }
+  factory GKitchen.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GKitchen.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GKitchen clone() => GKitchen()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GKitchen copyWith(void Function(GKitchen) updates) => super.copyWith((message) => updates(message as GKitchen)) as GKitchen; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GKitchen create() => GKitchen._();
+  GKitchen createEmptyInstance() => create();
+  static $pb.PbList<GKitchen> createRepeated() => $pb.PbList<GKitchen>();
+  @$core.pragma('dart2js:noInline')
+  static GKitchen getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GKitchen>(create);
+  static GKitchen? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$0.GRecipe> get recipeList => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.Map<$core.String, $0.GRecipe> get recipeMap => $_getMap(1);
+}
+
+class GListOfKitchen extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfKitchen', createEmptyInstance: create)
+    ..pc<GKitchen>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GKitchen.create)
+    ..hasRequiredFields = false
+  ;
+
+  GListOfKitchen._() : super();
+  factory GListOfKitchen({
+    $core.Iterable<GKitchen>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfKitchen.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GListOfKitchen.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GListOfKitchen clone() => GListOfKitchen()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GListOfKitchen copyWith(void Function(GListOfKitchen) updates) => super.copyWith((message) => updates(message as GListOfKitchen)) as GListOfKitchen; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfKitchen create() => GListOfKitchen._();
+  GListOfKitchen createEmptyInstance() => create();
+  static $pb.PbList<GListOfKitchen> createRepeated() => $pb.PbList<GListOfKitchen>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfKitchen getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfKitchen>(create);
+  static GListOfKitchen? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GKitchen> get items => $_getList(0);
+}
+
+class GChef extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GChef', createEmptyInstance: create)
+    ..aOM<$0.GRecipe>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteRecipe', protoName: 'favoriteRecipe', subBuilder: $0.GRecipe.create)
+    ..aOM<GKnife>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteKnife', protoName: 'favoriteKnife', subBuilder: GKnife.create)
+    ..e<$6.GApplianceType>(3, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'favoriteApplianceType', $pb.PbFieldType.OE, protoName: 'favoriteApplianceType', defaultOrMaker: $6.GApplianceType.heat, valueOf: $6.GApplianceType.valueOf, enumValues: $6.GApplianceType.values)
+    ..hasRequiredFields = false
+  ;
+
+  GChef._() : super();
+  factory GChef({
+    $0.GRecipe? favoriteRecipe,
+    GKnife? favoriteKnife,
+    $6.GApplianceType? favoriteApplianceType,
+  }) {
+    final _result = create();
+    if (favoriteRecipe != null) {
+      _result.favoriteRecipe = favoriteRecipe;
+    }
+    if (favoriteKnife != null) {
+      _result.favoriteKnife = favoriteKnife;
+    }
+    if (favoriteApplianceType != null) {
+      _result.favoriteApplianceType = favoriteApplianceType;
+    }
+    return _result;
+  }
+  factory GChef.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GChef.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GChef clone() => GChef()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GChef copyWith(void Function(GChef) updates) => super.copyWith((message) => updates(message as GChef)) as GChef; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GChef create() => GChef._();
+  GChef createEmptyInstance() => create();
+  static $pb.PbList<GChef> createRepeated() => $pb.PbList<GChef>();
+  @$core.pragma('dart2js:noInline')
+  static GChef getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GChef>(create);
+  static GChef? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $0.GRecipe get favoriteRecipe => $_getN(0);
+  @$pb.TagNumber(1)
+  set favoriteRecipe($0.GRecipe v) { setField(1, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasFavoriteRecipe() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearFavoriteRecipe() => clearField(1);
+  @$pb.TagNumber(1)
+  $0.GRecipe ensureFavoriteRecipe() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  GKnife get favoriteKnife => $_getN(1);
+  @$pb.TagNumber(2)
+  set favoriteKnife(GKnife v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasFavoriteKnife() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearFavoriteKnife() => clearField(2);
+  @$pb.TagNumber(2)
+  GKnife ensureFavoriteKnife() => $_ensure(1);
+
+  @$pb.TagNumber(3)
+  $6.GApplianceType get favoriteApplianceType => $_getN(2);
+  @$pb.TagNumber(3)
+  set favoriteApplianceType($6.GApplianceType v) { setField(3, v); }
+  @$pb.TagNumber(3)
+  $core.bool hasFavoriteApplianceType() => $_has(2);
+  @$pb.TagNumber(3)
+  void clearFavoriteApplianceType() => clearField(3);
+}
+
+class GListOfChef extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfChef', createEmptyInstance: create)
+    ..pc<GChef>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GChef.create)
+    ..hasRequiredFields = false
+  ;
+
+  GListOfChef._() : super();
+  factory GListOfChef({
+    $core.Iterable<GChef>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfChef.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GListOfChef.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GListOfChef clone() => GListOfChef()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GListOfChef copyWith(void Function(GListOfChef) updates) => super.copyWith((message) => updates(message as GListOfChef)) as GListOfChef; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfChef create() => GListOfChef._();
+  GListOfChef createEmptyInstance() => create();
+  static $pb.PbList<GListOfChef> createRepeated() => $pb.PbList<GListOfChef>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfChef getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfChef>(create);
+  static GListOfChef? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GChef> get items => $_getList(0);
+}
+
+class GInventory extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GInventory', createEmptyInstance: create)
+    ..m<$core.String, $core.int>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'numberOfThings', protoName: 'numberOfThings', entryClassName: 'GInventory.NumberOfThingsEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.O3)
+    ..m<$core.String, $0.GRecipe>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'recipesByName', protoName: 'recipesByName', entryClassName: 'GInventory.RecipesByNameEntry', keyFieldType: $pb.PbFieldType.OS, valueFieldType: $pb.PbFieldType.OM, valueCreator: $0.GRecipe.create)
+    ..hasRequiredFields = false
+  ;
+
+  GInventory._() : super();
+  factory GInventory({
+    $core.Map<$core.String, $core.int>? numberOfThings,
+    $core.Map<$core.String, $0.GRecipe>? recipesByName,
+  }) {
+    final _result = create();
+    if (numberOfThings != null) {
+      _result.numberOfThings.addAll(numberOfThings);
+    }
+    if (recipesByName != null) {
+      _result.recipesByName.addAll(recipesByName);
+    }
+    return _result;
+  }
+  factory GInventory.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GInventory.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GInventory clone() => GInventory()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GInventory copyWith(void Function(GInventory) updates) => super.copyWith((message) => updates(message as GInventory)) as GInventory; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GInventory create() => GInventory._();
+  GInventory createEmptyInstance() => create();
+  static $pb.PbList<GInventory> createRepeated() => $pb.PbList<GInventory>();
+  @$core.pragma('dart2js:noInline')
+  static GInventory getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GInventory>(create);
+  static GInventory? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.Map<$core.String, $core.int> get numberOfThings => $_getMap(0);
+
+  @$pb.TagNumber(2)
+  $core.Map<$core.String, $0.GRecipe> get recipesByName => $_getMap(1);
+}
+
+class GListOfInventory extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'GListOfInventory', createEmptyInstance: create)
+    ..pc<GInventory>(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'items', $pb.PbFieldType.PM, subBuilder: GInventory.create)
+    ..hasRequiredFields = false
+  ;
+
+  GListOfInventory._() : super();
+  factory GListOfInventory({
+    $core.Iterable<GInventory>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfInventory.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory GListOfInventory.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  GListOfInventory clone() => GListOfInventory()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  GListOfInventory copyWith(void Function(GListOfInventory) updates) => super.copyWith((message) => updates(message as GListOfInventory)) as GListOfInventory; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfInventory create() => GListOfInventory._();
+  GListOfInventory createEmptyInstance() => create();
+  static $pb.PbList<GListOfInventory> createRepeated() => $pb.PbList<GListOfInventory>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfInventory getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<GListOfInventory>(create);
+  static GListOfInventory? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GInventory> get items => $_getList(0);
+}
+
+class NullableGKnifeType extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(const $core.bool.fromEnvironment('protobuf.omit_message_names') ? '' : 'NullableGKnifeType', createEmptyInstance: create)
+    ..aOB(1, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'hasValue', protoName: 'hasValue')
+    ..e<GKnifeType>(2, const $core.bool.fromEnvironment('protobuf.omit_field_names') ? '' : 'value', $pb.PbFieldType.OE, defaultOrMaker: GKnifeType.chefsKnife, valueOf: GKnifeType.valueOf, enumValues: GKnifeType.values)
+    ..hasRequiredFields = false
+  ;
+
+  NullableGKnifeType._() : super();
+  factory NullableGKnifeType({
+    $core.bool? hasValue,
+    GKnifeType? value_2,
+  }) {
+    final _result = create();
+    if (hasValue != null) {
+      _result.hasValue = hasValue;
+    }
+    if (value_2 != null) {
+      _result.value_2 = value_2;
+    }
+    return _result;
+  }
+  factory NullableGKnifeType.fromBuffer($core.List<$core.int> i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromBuffer(i, r);
+  factory NullableGKnifeType.fromJson($core.String i, [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) => create()..mergeFromJson(i, r);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+  'Will be removed in next major version')
+  NullableGKnifeType clone() => NullableGKnifeType()..mergeFromMessage(this);
+  @$core.Deprecated(
+  'Using this can add significant overhead to your binary. '
+  'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+  'Will be removed in next major version')
+  NullableGKnifeType copyWith(void Function(NullableGKnifeType) updates) => super.copyWith((message) => updates(message as NullableGKnifeType)) as NullableGKnifeType; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static NullableGKnifeType create() => NullableGKnifeType._();
+  NullableGKnifeType createEmptyInstance() => create();
+  static $pb.PbList<NullableGKnifeType> createRepeated() => $pb.PbList<NullableGKnifeType>();
+  @$core.pragma('dart2js:noInline')
+  static NullableGKnifeType getDefault() => _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<NullableGKnifeType>(create);
+  static NullableGKnifeType? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.bool get hasValue => $_getBF(0);
+  @$pb.TagNumber(1)
+  set hasValue($core.bool v) { $_setBool(0, v); }
+  @$pb.TagNumber(1)
+  $core.bool hasHasValue() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearHasValue() => clearField(1);
+
+  @$pb.TagNumber(2)
+  GKnifeType get value_2 => $_getN(1);
+  @$pb.TagNumber(2)
+  set value_2(GKnifeType v) { setField(2, v); }
+  @$pb.TagNumber(2)
+  $core.bool hasValue_2() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearValue_2() => clearField(2);
+}
+

--- a/proto_mapper/test/lib/grpc/utensils.pbenum.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pbenum.dart
@@ -1,0 +1,28 @@
+///
+//  Generated code. Do not modify.
+//  source: utensils.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+// ignore_for_file: UNDEFINED_SHOWN_NAME
+import 'dart:core' as $core;
+import 'package:protobuf/protobuf.dart' as $pb;
+
+class GKnifeType extends $pb.ProtobufEnum {
+  static const GKnifeType chefsKnife = GKnifeType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'chefsKnife');
+  static const GKnifeType paringKnife = GKnifeType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'paringKnife');
+  static const GKnifeType breadKnife = GKnifeType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'breadKnife');
+
+  static const $core.List<GKnifeType> values = <GKnifeType> [
+    chefsKnife,
+    paringKnife,
+    breadKnife,
+  ];
+
+  static final $core.Map<$core.int, GKnifeType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static GKnifeType? valueOf($core.int value) => _byValue[value];
+
+  const GKnifeType._($core.int v, $core.String n) : super(v, n);
+}
+

--- a/proto_mapper/test/lib/grpc/utensils.pbenum.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pbenum.dart
@@ -10,19 +10,31 @@ import 'dart:core' as $core;
 import 'package:protobuf/protobuf.dart' as $pb;
 
 class GKnifeType extends $pb.ProtobufEnum {
-  static const GKnifeType chefsKnife = GKnifeType._(0, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'chefsKnife');
-  static const GKnifeType paringKnife = GKnifeType._(1, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'paringKnife');
-  static const GKnifeType breadKnife = GKnifeType._(2, const $core.bool.fromEnvironment('protobuf.omit_enum_names') ? '' : 'breadKnife');
+  static const GKnifeType chefsKnife = GKnifeType._(
+      0,
+      $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'chefsKnife');
+  static const GKnifeType paringKnife = GKnifeType._(
+      1,
+      $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'paringKnife');
+  static const GKnifeType breadKnife = GKnifeType._(
+      2,
+      $core.bool.fromEnvironment('protobuf.omit_enum_names')
+          ? ''
+          : 'breadKnife');
 
-  static const $core.List<GKnifeType> values = <GKnifeType> [
+  static const $core.List<GKnifeType> values = <GKnifeType>[
     chefsKnife,
     paringKnife,
     breadKnife,
   ];
 
-  static final $core.Map<$core.int, GKnifeType> _byValue = $pb.ProtobufEnum.initByValue(values);
+  static final $core.Map<$core.int, GKnifeType> _byValue =
+      $pb.ProtobufEnum.initByValue(values);
   static GKnifeType? valueOf($core.int value) => _byValue[value];
 
   const GKnifeType._($core.int v, $core.String n) : super(v, n);
 }
-

--- a/proto_mapper/test/lib/grpc/utensils.pbjson.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pbjson.dart
@@ -1,0 +1,171 @@
+///
+//  Generated code. Do not modify.
+//  source: utensils.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+@$core.Deprecated('Use gKnifeTypeDescriptor instead')
+const GKnifeType$json = const {
+  '1': 'GKnifeType',
+  '2': const [
+    const {'1': 'chefsKnife', '2': 0},
+    const {'1': 'paringKnife', '2': 1},
+    const {'1': 'breadKnife', '2': 2},
+  ],
+};
+
+/// Descriptor for `GKnifeType`. Decode as a `google.protobuf.EnumDescriptorProto`.
+final $typed_data.Uint8List gKnifeTypeDescriptor = $convert.base64Decode('CgpHS25pZmVUeXBlEg4KCmNoZWZzS25pZmUQABIPCgtwYXJpbmdLbmlmZRABEg4KCmJyZWFkS25pZmUQAg==');
+@$core.Deprecated('Use gKnifeDescriptor instead')
+const GKnife$json = const {
+  '1': 'GKnife',
+  '2': const [
+    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'type', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'type'},
+  ],
+};
+
+/// Descriptor for `GKnife`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gKnifeDescriptor = $convert.base64Decode('CgZHS25pZmUSEgoEbmFtZRgBIAEoCVIEbmFtZRIfCgR0eXBlGAIgASgOMgsuR0tuaWZlVHlwZVIEdHlwZQ==');
+@$core.Deprecated('Use gListOfKnifeDescriptor instead')
+const GListOfKnife$json = const {
+  '1': 'GListOfKnife',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKnife', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfKnife`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfKnifeDescriptor = $convert.base64Decode('CgxHTGlzdE9mS25pZmUSHQoFaXRlbXMYASADKAsyBy5HS25pZmVSBWl0ZW1z');
+@$core.Deprecated('Use gGarlicPressDescriptor instead')
+const GGarlicPress$json = const {
+  '1': 'GGarlicPress',
+  '2': const [
+    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    const {'1': 'machineWashable', '3': 2, '4': 1, '5': 8, '10': 'machineWashable'},
+  ],
+};
+
+/// Descriptor for `GGarlicPress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gGarlicPressDescriptor = $convert.base64Decode('CgxHR2FybGljUHJlc3MSEgoEbmFtZRgBIAEoCVIEbmFtZRIoCg9tYWNoaW5lV2FzaGFibGUYAiABKAhSD21hY2hpbmVXYXNoYWJsZQ==');
+@$core.Deprecated('Use gListOfGarlicPressDescriptor instead')
+const GListOfGarlicPress$json = const {
+  '1': 'GListOfGarlicPress',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GGarlicPress', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfGarlicPress`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfGarlicPressDescriptor = $convert.base64Decode('ChJHTGlzdE9mR2FybGljUHJlc3MSIwoFaXRlbXMYASADKAsyDS5HR2FybGljUHJlc3NSBWl0ZW1z');
+@$core.Deprecated('Use gKitchenDescriptor instead')
+const GKitchen$json = const {
+  '1': 'GKitchen',
+  '2': const [
+    const {'1': 'recipeList', '3': 1, '4': 3, '5': 11, '6': '.GRecipe', '10': 'recipeList'},
+    const {'1': 'recipeMap', '3': 2, '4': 3, '5': 11, '6': '.GKitchen.RecipeMapEntry', '10': 'recipeMap'},
+  ],
+  '3': const [GKitchen_RecipeMapEntry$json],
+};
+
+@$core.Deprecated('Use gKitchenDescriptor instead')
+const GKitchen_RecipeMapEntry$json = const {
+  '1': 'RecipeMapEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+
+/// Descriptor for `GKitchen`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gKitchenDescriptor = $convert.base64Decode('CghHS2l0Y2hlbhIoCgpyZWNpcGVMaXN0GAEgAygLMgguR1JlY2lwZVIKcmVjaXBlTGlzdBI2CglyZWNpcGVNYXAYAiADKAsyGC5HS2l0Y2hlbi5SZWNpcGVNYXBFbnRyeVIJcmVjaXBlTWFwGkYKDlJlY2lwZU1hcEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh4KBXZhbHVlGAIgASgLMgguR1JlY2lwZVIFdmFsdWU6AjgB');
+@$core.Deprecated('Use gListOfKitchenDescriptor instead')
+const GListOfKitchen$json = const {
+  '1': 'GListOfKitchen',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKitchen', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfKitchen`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfKitchenDescriptor = $convert.base64Decode('Cg5HTGlzdE9mS2l0Y2hlbhIfCgVpdGVtcxgBIAMoCzIJLkdLaXRjaGVuUgVpdGVtcw==');
+@$core.Deprecated('Use gChefDescriptor instead')
+const GChef$json = const {
+  '1': 'GChef',
+  '2': const [
+    const {'1': 'favoriteRecipe', '3': 1, '4': 1, '5': 11, '6': '.GRecipe', '10': 'favoriteRecipe'},
+    const {'1': 'favoriteKnife', '3': 2, '4': 1, '5': 11, '6': '.GKnife', '10': 'favoriteKnife'},
+    const {'1': 'favoriteApplianceType', '3': 3, '4': 1, '5': 14, '6': '.GApplianceType', '10': 'favoriteApplianceType'},
+  ],
+};
+
+/// Descriptor for `GChef`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gChefDescriptor = $convert.base64Decode('CgVHQ2hlZhIwCg5mYXZvcml0ZVJlY2lwZRgBIAEoCzIILkdSZWNpcGVSDmZhdm9yaXRlUmVjaXBlEi0KDWZhdm9yaXRlS25pZmUYAiABKAsyBy5HS25pZmVSDWZhdm9yaXRlS25pZmUSRQoVZmF2b3JpdGVBcHBsaWFuY2VUeXBlGAMgASgOMg8uR0FwcGxpYW5jZVR5cGVSFWZhdm9yaXRlQXBwbGlhbmNlVHlwZQ==');
+@$core.Deprecated('Use gListOfChefDescriptor instead')
+const GListOfChef$json = const {
+  '1': 'GListOfChef',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GChef', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfChef`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfChefDescriptor = $convert.base64Decode('CgtHTGlzdE9mQ2hlZhIcCgVpdGVtcxgBIAMoCzIGLkdDaGVmUgVpdGVtcw==');
+@$core.Deprecated('Use gInventoryDescriptor instead')
+const GInventory$json = const {
+  '1': 'GInventory',
+  '2': const [
+    const {'1': 'numberOfThings', '3': 1, '4': 3, '5': 11, '6': '.GInventory.NumberOfThingsEntry', '10': 'numberOfThings'},
+    const {'1': 'recipesByName', '3': 2, '4': 3, '5': 11, '6': '.GInventory.RecipesByNameEntry', '10': 'recipesByName'},
+  ],
+  '3': const [GInventory_NumberOfThingsEntry$json, GInventory_RecipesByNameEntry$json],
+};
+
+@$core.Deprecated('Use gInventoryDescriptor instead')
+const GInventory_NumberOfThingsEntry$json = const {
+  '1': 'NumberOfThingsEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 5, '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+
+@$core.Deprecated('Use gInventoryDescriptor instead')
+const GInventory_RecipesByNameEntry$json = const {
+  '1': 'RecipesByNameEntry',
+  '2': const [
+    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
+  ],
+  '7': const {'7': true},
+};
+
+/// Descriptor for `GInventory`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gInventoryDescriptor = $convert.base64Decode('CgpHSW52ZW50b3J5EkcKDm51bWJlck9mVGhpbmdzGAEgAygLMh8uR0ludmVudG9yeS5OdW1iZXJPZlRoaW5nc0VudHJ5Ug5udW1iZXJPZlRoaW5ncxJECg1yZWNpcGVzQnlOYW1lGAIgAygLMh4uR0ludmVudG9yeS5SZWNpcGVzQnlOYW1lRW50cnlSDXJlY2lwZXNCeU5hbWUaQQoTTnVtYmVyT2ZUaGluZ3NFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBVIFdmFsdWU6AjgBGkoKElJlY2lwZXNCeU5hbWVFbnRyeRIQCgNrZXkYASABKAlSA2tleRIeCgV2YWx1ZRgCIAEoCzIILkdSZWNpcGVSBXZhbHVlOgI4AQ==');
+@$core.Deprecated('Use gListOfInventoryDescriptor instead')
+const GListOfInventory$json = const {
+  '1': 'GListOfInventory',
+  '2': const [
+    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GInventory', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfInventory`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfInventoryDescriptor = $convert.base64Decode('ChBHTGlzdE9mSW52ZW50b3J5EiEKBWl0ZW1zGAEgAygLMgsuR0ludmVudG9yeVIFaXRlbXM=');
+@$core.Deprecated('Use nullableGKnifeTypeDescriptor instead')
+const NullableGKnifeType$json = const {
+  '1': 'NullableGKnifeType',
+  '2': const [
+    const {'1': 'hasValue', '3': 1, '4': 1, '5': 8, '10': 'hasValue'},
+    const {'1': 'value', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'value'},
+  ],
+};
+
+/// Descriptor for `NullableGKnifeType`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List nullableGKnifeTypeDescriptor = $convert.base64Decode('ChJOdWxsYWJsZUdLbmlmZVR5cGUSGgoIaGFzVmFsdWUYASABKAhSCGhhc1ZhbHVlEiEKBXZhbHVlGAIgASgOMgsuR0tuaWZlVHlwZVIFdmFsdWU=');

--- a/proto_mapper/test/lib/grpc/utensils.pbjson.dart
+++ b/proto_mapper/test/lib/grpc/utensils.pbjson.dart
@@ -8,164 +8,236 @@
 import 'dart:core' as $core;
 import 'dart:convert' as $convert;
 import 'dart:typed_data' as $typed_data;
+
 @$core.Deprecated('Use gKnifeTypeDescriptor instead')
-const GKnifeType$json = const {
+const GKnifeType$json = {
   '1': 'GKnifeType',
-  '2': const [
-    const {'1': 'chefsKnife', '2': 0},
-    const {'1': 'paringKnife', '2': 1},
-    const {'1': 'breadKnife', '2': 2},
+  '2': [
+    {'1': 'chefsKnife', '2': 0},
+    {'1': 'paringKnife', '2': 1},
+    {'1': 'breadKnife', '2': 2},
   ],
 };
 
 /// Descriptor for `GKnifeType`. Decode as a `google.protobuf.EnumDescriptorProto`.
-final $typed_data.Uint8List gKnifeTypeDescriptor = $convert.base64Decode('CgpHS25pZmVUeXBlEg4KCmNoZWZzS25pZmUQABIPCgtwYXJpbmdLbmlmZRABEg4KCmJyZWFkS25pZmUQAg==');
+final $typed_data.Uint8List gKnifeTypeDescriptor = $convert.base64Decode(
+    'CgpHS25pZmVUeXBlEg4KCmNoZWZzS25pZmUQABIPCgtwYXJpbmdLbmlmZRABEg4KCmJyZWFkS25pZmUQAg==');
 @$core.Deprecated('Use gKnifeDescriptor instead')
-const GKnife$json = const {
+const GKnife$json = {
   '1': 'GKnife',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'type', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'type'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'type', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'type'},
   ],
 };
 
 /// Descriptor for `GKnife`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gKnifeDescriptor = $convert.base64Decode('CgZHS25pZmUSEgoEbmFtZRgBIAEoCVIEbmFtZRIfCgR0eXBlGAIgASgOMgsuR0tuaWZlVHlwZVIEdHlwZQ==');
+final $typed_data.Uint8List gKnifeDescriptor = $convert.base64Decode(
+    'CgZHS25pZmUSEgoEbmFtZRgBIAEoCVIEbmFtZRIfCgR0eXBlGAIgASgOMgsuR0tuaWZlVHlwZVIEdHlwZQ==');
 @$core.Deprecated('Use gListOfKnifeDescriptor instead')
-const GListOfKnife$json = const {
+const GListOfKnife$json = {
   '1': 'GListOfKnife',
-  '2': const [
-    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKnife', '10': 'items'},
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKnife', '10': 'items'},
   ],
 };
 
 /// Descriptor for `GListOfKnife`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gListOfKnifeDescriptor = $convert.base64Decode('CgxHTGlzdE9mS25pZmUSHQoFaXRlbXMYASADKAsyBy5HS25pZmVSBWl0ZW1z');
+final $typed_data.Uint8List gListOfKnifeDescriptor = $convert.base64Decode(
+    'CgxHTGlzdE9mS25pZmUSHQoFaXRlbXMYASADKAsyBy5HS25pZmVSBWl0ZW1z');
 @$core.Deprecated('Use gGarlicPressDescriptor instead')
-const GGarlicPress$json = const {
+const GGarlicPress$json = {
   '1': 'GGarlicPress',
-  '2': const [
-    const {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
-    const {'1': 'machineWashable', '3': 2, '4': 1, '5': 8, '10': 'machineWashable'},
+  '2': [
+    {'1': 'name', '3': 1, '4': 1, '5': 9, '10': 'name'},
+    {'1': 'machineWashable', '3': 2, '4': 1, '5': 8, '10': 'machineWashable'},
   ],
 };
 
 /// Descriptor for `GGarlicPress`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gGarlicPressDescriptor = $convert.base64Decode('CgxHR2FybGljUHJlc3MSEgoEbmFtZRgBIAEoCVIEbmFtZRIoCg9tYWNoaW5lV2FzaGFibGUYAiABKAhSD21hY2hpbmVXYXNoYWJsZQ==');
+final $typed_data.Uint8List gGarlicPressDescriptor = $convert.base64Decode(
+    'CgxHR2FybGljUHJlc3MSEgoEbmFtZRgBIAEoCVIEbmFtZRIoCg9tYWNoaW5lV2FzaGFibGUYAiABKAhSD21hY2hpbmVXYXNoYWJsZQ==');
 @$core.Deprecated('Use gListOfGarlicPressDescriptor instead')
-const GListOfGarlicPress$json = const {
+const GListOfGarlicPress$json = {
   '1': 'GListOfGarlicPress',
-  '2': const [
-    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GGarlicPress', '10': 'items'},
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GGarlicPress',
+      '10': 'items'
+    },
   ],
 };
 
 /// Descriptor for `GListOfGarlicPress`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gListOfGarlicPressDescriptor = $convert.base64Decode('ChJHTGlzdE9mR2FybGljUHJlc3MSIwoFaXRlbXMYASADKAsyDS5HR2FybGljUHJlc3NSBWl0ZW1z');
+final $typed_data.Uint8List gListOfGarlicPressDescriptor = $convert.base64Decode(
+    'ChJHTGlzdE9mR2FybGljUHJlc3MSIwoFaXRlbXMYASADKAsyDS5HR2FybGljUHJlc3NSBWl0ZW1z');
 @$core.Deprecated('Use gKitchenDescriptor instead')
-const GKitchen$json = const {
+const GKitchen$json = {
   '1': 'GKitchen',
-  '2': const [
-    const {'1': 'recipeList', '3': 1, '4': 3, '5': 11, '6': '.GRecipe', '10': 'recipeList'},
-    const {'1': 'recipeMap', '3': 2, '4': 3, '5': 11, '6': '.GKitchen.RecipeMapEntry', '10': 'recipeMap'},
+  '2': [
+    {
+      '1': 'recipeList',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GRecipe',
+      '10': 'recipeList'
+    },
+    {
+      '1': 'recipeMap',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.GKitchen.RecipeMapEntry',
+      '10': 'recipeMap'
+    },
   ],
-  '3': const [GKitchen_RecipeMapEntry$json],
+  '3': [GKitchen_RecipeMapEntry$json],
 };
 
 @$core.Deprecated('Use gKitchenDescriptor instead')
-const GKitchen_RecipeMapEntry$json = const {
+const GKitchen_RecipeMapEntry$json = {
   '1': 'RecipeMapEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `GKitchen`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gKitchenDescriptor = $convert.base64Decode('CghHS2l0Y2hlbhIoCgpyZWNpcGVMaXN0GAEgAygLMgguR1JlY2lwZVIKcmVjaXBlTGlzdBI2CglyZWNpcGVNYXAYAiADKAsyGC5HS2l0Y2hlbi5SZWNpcGVNYXBFbnRyeVIJcmVjaXBlTWFwGkYKDlJlY2lwZU1hcEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh4KBXZhbHVlGAIgASgLMgguR1JlY2lwZVIFdmFsdWU6AjgB');
+final $typed_data.Uint8List gKitchenDescriptor = $convert.base64Decode(
+    'CghHS2l0Y2hlbhIoCgpyZWNpcGVMaXN0GAEgAygLMgguR1JlY2lwZVIKcmVjaXBlTGlzdBI2CglyZWNpcGVNYXAYAiADKAsyGC5HS2l0Y2hlbi5SZWNpcGVNYXBFbnRyeVIJcmVjaXBlTWFwGkYKDlJlY2lwZU1hcEVudHJ5EhAKA2tleRgBIAEoCVIDa2V5Eh4KBXZhbHVlGAIgASgLMgguR1JlY2lwZVIFdmFsdWU6AjgB');
 @$core.Deprecated('Use gListOfKitchenDescriptor instead')
-const GListOfKitchen$json = const {
+const GListOfKitchen$json = {
   '1': 'GListOfKitchen',
-  '2': const [
-    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKitchen', '10': 'items'},
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GKitchen', '10': 'items'},
   ],
 };
 
 /// Descriptor for `GListOfKitchen`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gListOfKitchenDescriptor = $convert.base64Decode('Cg5HTGlzdE9mS2l0Y2hlbhIfCgVpdGVtcxgBIAMoCzIJLkdLaXRjaGVuUgVpdGVtcw==');
+final $typed_data.Uint8List gListOfKitchenDescriptor = $convert.base64Decode(
+    'Cg5HTGlzdE9mS2l0Y2hlbhIfCgVpdGVtcxgBIAMoCzIJLkdLaXRjaGVuUgVpdGVtcw==');
 @$core.Deprecated('Use gChefDescriptor instead')
-const GChef$json = const {
+const GChef$json = {
   '1': 'GChef',
-  '2': const [
-    const {'1': 'favoriteRecipe', '3': 1, '4': 1, '5': 11, '6': '.GRecipe', '10': 'favoriteRecipe'},
-    const {'1': 'favoriteKnife', '3': 2, '4': 1, '5': 11, '6': '.GKnife', '10': 'favoriteKnife'},
-    const {'1': 'favoriteApplianceType', '3': 3, '4': 1, '5': 14, '6': '.GApplianceType', '10': 'favoriteApplianceType'},
+  '2': [
+    {
+      '1': 'favoriteRecipe',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.GRecipe',
+      '10': 'favoriteRecipe'
+    },
+    {
+      '1': 'favoriteKnife',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.GKnife',
+      '10': 'favoriteKnife'
+    },
+    {
+      '1': 'favoriteApplianceType',
+      '3': 3,
+      '4': 1,
+      '5': 14,
+      '6': '.GApplianceType',
+      '10': 'favoriteApplianceType'
+    },
   ],
 };
 
 /// Descriptor for `GChef`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gChefDescriptor = $convert.base64Decode('CgVHQ2hlZhIwCg5mYXZvcml0ZVJlY2lwZRgBIAEoCzIILkdSZWNpcGVSDmZhdm9yaXRlUmVjaXBlEi0KDWZhdm9yaXRlS25pZmUYAiABKAsyBy5HS25pZmVSDWZhdm9yaXRlS25pZmUSRQoVZmF2b3JpdGVBcHBsaWFuY2VUeXBlGAMgASgOMg8uR0FwcGxpYW5jZVR5cGVSFWZhdm9yaXRlQXBwbGlhbmNlVHlwZQ==');
+final $typed_data.Uint8List gChefDescriptor = $convert.base64Decode(
+    'CgVHQ2hlZhIwCg5mYXZvcml0ZVJlY2lwZRgBIAEoCzIILkdSZWNpcGVSDmZhdm9yaXRlUmVjaXBlEi0KDWZhdm9yaXRlS25pZmUYAiABKAsyBy5HS25pZmVSDWZhdm9yaXRlS25pZmUSRQoVZmF2b3JpdGVBcHBsaWFuY2VUeXBlGAMgASgOMg8uR0FwcGxpYW5jZVR5cGVSFWZhdm9yaXRlQXBwbGlhbmNlVHlwZQ==');
 @$core.Deprecated('Use gListOfChefDescriptor instead')
-const GListOfChef$json = const {
+const GListOfChef$json = {
   '1': 'GListOfChef',
-  '2': const [
-    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GChef', '10': 'items'},
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GChef', '10': 'items'},
   ],
 };
 
 /// Descriptor for `GListOfChef`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gListOfChefDescriptor = $convert.base64Decode('CgtHTGlzdE9mQ2hlZhIcCgVpdGVtcxgBIAMoCzIGLkdDaGVmUgVpdGVtcw==');
+final $typed_data.Uint8List gListOfChefDescriptor = $convert.base64Decode(
+    'CgtHTGlzdE9mQ2hlZhIcCgVpdGVtcxgBIAMoCzIGLkdDaGVmUgVpdGVtcw==');
 @$core.Deprecated('Use gInventoryDescriptor instead')
-const GInventory$json = const {
+const GInventory$json = {
   '1': 'GInventory',
-  '2': const [
-    const {'1': 'numberOfThings', '3': 1, '4': 3, '5': 11, '6': '.GInventory.NumberOfThingsEntry', '10': 'numberOfThings'},
-    const {'1': 'recipesByName', '3': 2, '4': 3, '5': 11, '6': '.GInventory.RecipesByNameEntry', '10': 'recipesByName'},
+  '2': [
+    {
+      '1': 'numberOfThings',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GInventory.NumberOfThingsEntry',
+      '10': 'numberOfThings'
+    },
+    {
+      '1': 'recipesByName',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.GInventory.RecipesByNameEntry',
+      '10': 'recipesByName'
+    },
   ],
-  '3': const [GInventory_NumberOfThingsEntry$json, GInventory_RecipesByNameEntry$json],
+  '3': [
+    GInventory_NumberOfThingsEntry$json,
+    GInventory_RecipesByNameEntry$json
+  ],
 };
 
 @$core.Deprecated('Use gInventoryDescriptor instead')
-const GInventory_NumberOfThingsEntry$json = const {
+const GInventory_NumberOfThingsEntry$json = {
   '1': 'NumberOfThingsEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 5, '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 5, '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 @$core.Deprecated('Use gInventoryDescriptor instead')
-const GInventory_RecipesByNameEntry$json = const {
+const GInventory_RecipesByNameEntry$json = {
   '1': 'RecipesByNameEntry',
-  '2': const [
-    const {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {'1': 'value', '3': 2, '4': 1, '5': 11, '6': '.GRecipe', '10': 'value'},
   ],
-  '7': const {'7': true},
+  '7': {'7': true},
 };
 
 /// Descriptor for `GInventory`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gInventoryDescriptor = $convert.base64Decode('CgpHSW52ZW50b3J5EkcKDm51bWJlck9mVGhpbmdzGAEgAygLMh8uR0ludmVudG9yeS5OdW1iZXJPZlRoaW5nc0VudHJ5Ug5udW1iZXJPZlRoaW5ncxJECg1yZWNpcGVzQnlOYW1lGAIgAygLMh4uR0ludmVudG9yeS5SZWNpcGVzQnlOYW1lRW50cnlSDXJlY2lwZXNCeU5hbWUaQQoTTnVtYmVyT2ZUaGluZ3NFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBVIFdmFsdWU6AjgBGkoKElJlY2lwZXNCeU5hbWVFbnRyeRIQCgNrZXkYASABKAlSA2tleRIeCgV2YWx1ZRgCIAEoCzIILkdSZWNpcGVSBXZhbHVlOgI4AQ==');
+final $typed_data.Uint8List gInventoryDescriptor = $convert.base64Decode(
+    'CgpHSW52ZW50b3J5EkcKDm51bWJlck9mVGhpbmdzGAEgAygLMh8uR0ludmVudG9yeS5OdW1iZXJPZlRoaW5nc0VudHJ5Ug5udW1iZXJPZlRoaW5ncxJECg1yZWNpcGVzQnlOYW1lGAIgAygLMh4uR0ludmVudG9yeS5SZWNpcGVzQnlOYW1lRW50cnlSDXJlY2lwZXNCeU5hbWUaQQoTTnVtYmVyT2ZUaGluZ3NFbnRyeRIQCgNrZXkYASABKAlSA2tleRIUCgV2YWx1ZRgCIAEoBVIFdmFsdWU6AjgBGkoKElJlY2lwZXNCeU5hbWVFbnRyeRIQCgNrZXkYASABKAlSA2tleRIeCgV2YWx1ZRgCIAEoCzIILkdSZWNpcGVSBXZhbHVlOgI4AQ==');
 @$core.Deprecated('Use gListOfInventoryDescriptor instead')
-const GListOfInventory$json = const {
+const GListOfInventory$json = {
   '1': 'GListOfInventory',
-  '2': const [
-    const {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GInventory', '10': 'items'},
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GInventory', '10': 'items'},
   ],
 };
 
 /// Descriptor for `GListOfInventory`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List gListOfInventoryDescriptor = $convert.base64Decode('ChBHTGlzdE9mSW52ZW50b3J5EiEKBWl0ZW1zGAEgAygLMgsuR0ludmVudG9yeVIFaXRlbXM=');
+final $typed_data.Uint8List gListOfInventoryDescriptor = $convert.base64Decode(
+    'ChBHTGlzdE9mSW52ZW50b3J5EiEKBWl0ZW1zGAEgAygLMgsuR0ludmVudG9yeVIFaXRlbXM=');
 @$core.Deprecated('Use nullableGKnifeTypeDescriptor instead')
-const NullableGKnifeType$json = const {
+const NullableGKnifeType$json = {
   '1': 'NullableGKnifeType',
-  '2': const [
-    const {'1': 'hasValue', '3': 1, '4': 1, '5': 8, '10': 'hasValue'},
-    const {'1': 'value', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'value'},
+  '2': [
+    {'1': 'hasValue', '3': 1, '4': 1, '5': 8, '10': 'hasValue'},
+    {'1': 'value', '3': 2, '4': 1, '5': 14, '6': '.GKnifeType', '10': 'value'},
   ],
 };
 
 /// Descriptor for `NullableGKnifeType`. Decode as a `google.protobuf.DescriptorProto`.
-final $typed_data.Uint8List nullableGKnifeTypeDescriptor = $convert.base64Decode('ChJOdWxsYWJsZUdLbmlmZVR5cGUSGgoIaGFzVmFsdWUYASABKAhSCGhhc1ZhbHVlEiEKBXZhbHVlGAIgASgOMgsuR0tuaWZlVHlwZVIFdmFsdWU=');
+final $typed_data.Uint8List nullableGKnifeTypeDescriptor = $convert.base64Decode(
+    'ChJOdWxsYWJsZUdLbmlmZVR5cGUSGgoIaGFzVmFsdWUYASABKAhSCGhhc1ZhbHVlEiEKBXZhbHVlGAIgASgOMgsuR0tuaWZlVHlwZVIFdmFsdWU=');

--- a/proto_mapper/test/lib/src/constructors_host.dart
+++ b/proto_mapper/test/lib/src/constructors_host.dart
@@ -1,0 +1,190 @@
+import 'package:proto_annotations/proto_annotations.dart';
+import 'package:proto_generator_test/grpc/constructors_host.pb.dart';
+
+part 'constructors_host.g.dart';
+
+@proto
+@mapProto
+class ConstructObject1 {
+  late String name;
+
+  late int number;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject1 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject1{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject2 {
+  String name;
+
+  int number;
+
+  ConstructObject2(this.name, this.number);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject2 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject2{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject3 {
+  final String name;
+
+  int number;
+
+  ConstructObject3(this.name) : number = 3;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject3 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject3{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject4 {
+  final String name;
+
+  int number;
+
+  ConstructObject4({required this.name}) : number = 2;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject4 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject4{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject5 {
+  final String name;
+
+  final int number;
+
+  ConstructObject5.name(this.name, this.number);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject5 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject5{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject6 {
+  final String? name;
+
+  int? number;
+
+  ConstructObject6({this.name});
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject6 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject6{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject7 {
+  final int? number;
+
+  final String name;
+
+  ConstructObject7.name(this.name, this.number);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject7 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject7{name: $name, number: $number}';
+  }
+}
+
+@proto
+@mapProto
+class ConstructObject8 {
+  final int? number;
+
+  final String name;
+
+  ConstructObject8.incomplete(this.name) : number = 1;
+
+  ConstructObject8.incomplete2(this.number) : name = 'final';
+
+  ConstructObject8.complete(this.number, this.name);
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ConstructObject8 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+
+  @override
+  int get hashCode => name.hashCode ^ number.hashCode;
+
+  @override
+  String toString() {
+    return 'ConstructObject8{name: $name, number: $number}';
+  }
+}

--- a/proto_mapper/test/lib/src/constructors_host.dart
+++ b/proto_mapper/test/lib/src/constructors_host.dart
@@ -13,7 +13,10 @@ class ConstructObject1 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject1 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject1 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -36,7 +39,10 @@ class ConstructObject2 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject2 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject2 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -59,7 +65,10 @@ class ConstructObject3 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject3 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject3 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -82,7 +91,10 @@ class ConstructObject4 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject4 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject4 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -105,7 +117,10 @@ class ConstructObject5 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject5 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject5 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -128,7 +143,10 @@ class ConstructObject6 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject6 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject6 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -151,7 +169,10 @@ class ConstructObject7 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject7 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject7 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;
@@ -178,7 +199,10 @@ class ConstructObject8 {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is ConstructObject8 && runtimeType == other.runtimeType && name == other.name && number == other.number;
+      other is ConstructObject8 &&
+          runtimeType == other.runtimeType &&
+          name == other.name &&
+          number == other.number;
 
   @override
   int get hashCode => name.hashCode ^ number.hashCode;

--- a/proto_mapper/test/lib/src/constructors_host.g.dart
+++ b/proto_mapper/test/lib/src/constructors_host.g.dart
@@ -1,0 +1,450 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'constructors_host.dart';
+
+// **************************************************************************
+// ProtoMapperGenerator
+// **************************************************************************
+
+class $ConstructObject1ProtoMapper
+    implements ProtoMapper<ConstructObject1, GConstructObject1> {
+  const $ConstructObject1ProtoMapper();
+
+  @override
+  ConstructObject1 fromProto(GConstructObject1 proto) =>
+      _$ConstructObject1FromProto(proto);
+
+  @override
+  GConstructObject1 toProto(ConstructObject1 entity) =>
+      _$ConstructObject1ToProto(entity);
+
+  ConstructObject1 fromJson(String json) =>
+      _$ConstructObject1FromProto(GConstructObject1.fromJson(json));
+  String toJson(ConstructObject1 entity) =>
+      _$ConstructObject1ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject1 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject1 fromBase64Proto(String base64Proto) =>
+      GConstructObject1.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject1();
+}
+
+GConstructObject1 _$ConstructObject1ToProto(ConstructObject1 instance) {
+  var proto = GConstructObject1();
+
+  proto.name = instance.name;
+  proto.number = instance.number;
+
+  return proto;
+}
+
+ConstructObject1 _$ConstructObject1FromProto(GConstructObject1 instance) =>
+    ConstructObject1()
+      ..name = instance.name
+      ..number = instance.number;
+
+extension $ConstructObject1ProtoExtension on ConstructObject1 {
+  GConstructObject1 toProto() => _$ConstructObject1ToProto(this);
+  String toJson() => _$ConstructObject1ToProto(this).writeToJson();
+
+  static ConstructObject1 fromProto(GConstructObject1 proto) =>
+      _$ConstructObject1FromProto(proto);
+  static ConstructObject1 fromJson(String json) =>
+      _$ConstructObject1FromProto(GConstructObject1.fromJson(json));
+}
+
+extension $GConstructObject1ProtoExtension on GConstructObject1 {
+  ConstructObject1 toConstructObject1() => _$ConstructObject1FromProto(this);
+}
+
+class $ConstructObject2ProtoMapper
+    implements ProtoMapper<ConstructObject2, GConstructObject2> {
+  const $ConstructObject2ProtoMapper();
+
+  @override
+  ConstructObject2 fromProto(GConstructObject2 proto) =>
+      _$ConstructObject2FromProto(proto);
+
+  @override
+  GConstructObject2 toProto(ConstructObject2 entity) =>
+      _$ConstructObject2ToProto(entity);
+
+  ConstructObject2 fromJson(String json) =>
+      _$ConstructObject2FromProto(GConstructObject2.fromJson(json));
+  String toJson(ConstructObject2 entity) =>
+      _$ConstructObject2ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject2 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject2 fromBase64Proto(String base64Proto) =>
+      GConstructObject2.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject2();
+}
+
+GConstructObject2 _$ConstructObject2ToProto(ConstructObject2 instance) {
+  var proto = GConstructObject2();
+
+  proto.name = instance.name;
+  proto.number = instance.number;
+
+  return proto;
+}
+
+ConstructObject2 _$ConstructObject2FromProto(GConstructObject2 instance) =>
+    ConstructObject2(
+      instance.name,
+      instance.number,
+    );
+
+extension $ConstructObject2ProtoExtension on ConstructObject2 {
+  GConstructObject2 toProto() => _$ConstructObject2ToProto(this);
+  String toJson() => _$ConstructObject2ToProto(this).writeToJson();
+
+  static ConstructObject2 fromProto(GConstructObject2 proto) =>
+      _$ConstructObject2FromProto(proto);
+  static ConstructObject2 fromJson(String json) =>
+      _$ConstructObject2FromProto(GConstructObject2.fromJson(json));
+}
+
+extension $GConstructObject2ProtoExtension on GConstructObject2 {
+  ConstructObject2 toConstructObject2() => _$ConstructObject2FromProto(this);
+}
+
+class $ConstructObject3ProtoMapper
+    implements ProtoMapper<ConstructObject3, GConstructObject3> {
+  const $ConstructObject3ProtoMapper();
+
+  @override
+  ConstructObject3 fromProto(GConstructObject3 proto) =>
+      _$ConstructObject3FromProto(proto);
+
+  @override
+  GConstructObject3 toProto(ConstructObject3 entity) =>
+      _$ConstructObject3ToProto(entity);
+
+  ConstructObject3 fromJson(String json) =>
+      _$ConstructObject3FromProto(GConstructObject3.fromJson(json));
+  String toJson(ConstructObject3 entity) =>
+      _$ConstructObject3ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject3 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject3 fromBase64Proto(String base64Proto) =>
+      GConstructObject3.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject3();
+}
+
+GConstructObject3 _$ConstructObject3ToProto(ConstructObject3 instance) {
+  var proto = GConstructObject3();
+
+  proto.name = instance.name;
+  proto.number = instance.number;
+
+  return proto;
+}
+
+ConstructObject3 _$ConstructObject3FromProto(GConstructObject3 instance) =>
+    ConstructObject3(
+      instance.name,
+    )..number = instance.number;
+
+extension $ConstructObject3ProtoExtension on ConstructObject3 {
+  GConstructObject3 toProto() => _$ConstructObject3ToProto(this);
+  String toJson() => _$ConstructObject3ToProto(this).writeToJson();
+
+  static ConstructObject3 fromProto(GConstructObject3 proto) =>
+      _$ConstructObject3FromProto(proto);
+  static ConstructObject3 fromJson(String json) =>
+      _$ConstructObject3FromProto(GConstructObject3.fromJson(json));
+}
+
+extension $GConstructObject3ProtoExtension on GConstructObject3 {
+  ConstructObject3 toConstructObject3() => _$ConstructObject3FromProto(this);
+}
+
+class $ConstructObject4ProtoMapper
+    implements ProtoMapper<ConstructObject4, GConstructObject4> {
+  const $ConstructObject4ProtoMapper();
+
+  @override
+  ConstructObject4 fromProto(GConstructObject4 proto) =>
+      _$ConstructObject4FromProto(proto);
+
+  @override
+  GConstructObject4 toProto(ConstructObject4 entity) =>
+      _$ConstructObject4ToProto(entity);
+
+  ConstructObject4 fromJson(String json) =>
+      _$ConstructObject4FromProto(GConstructObject4.fromJson(json));
+  String toJson(ConstructObject4 entity) =>
+      _$ConstructObject4ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject4 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject4 fromBase64Proto(String base64Proto) =>
+      GConstructObject4.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject4();
+}
+
+GConstructObject4 _$ConstructObject4ToProto(ConstructObject4 instance) {
+  var proto = GConstructObject4();
+
+  proto.name = instance.name;
+  proto.number = instance.number;
+
+  return proto;
+}
+
+ConstructObject4 _$ConstructObject4FromProto(GConstructObject4 instance) =>
+    ConstructObject4(
+      name: instance.name,
+    )..number = instance.number;
+
+extension $ConstructObject4ProtoExtension on ConstructObject4 {
+  GConstructObject4 toProto() => _$ConstructObject4ToProto(this);
+  String toJson() => _$ConstructObject4ToProto(this).writeToJson();
+
+  static ConstructObject4 fromProto(GConstructObject4 proto) =>
+      _$ConstructObject4FromProto(proto);
+  static ConstructObject4 fromJson(String json) =>
+      _$ConstructObject4FromProto(GConstructObject4.fromJson(json));
+}
+
+extension $GConstructObject4ProtoExtension on GConstructObject4 {
+  ConstructObject4 toConstructObject4() => _$ConstructObject4FromProto(this);
+}
+
+class $ConstructObject5ProtoMapper
+    implements ProtoMapper<ConstructObject5, GConstructObject5> {
+  const $ConstructObject5ProtoMapper();
+
+  @override
+  ConstructObject5 fromProto(GConstructObject5 proto) =>
+      _$ConstructObject5FromProto(proto);
+
+  @override
+  GConstructObject5 toProto(ConstructObject5 entity) =>
+      _$ConstructObject5ToProto(entity);
+
+  ConstructObject5 fromJson(String json) =>
+      _$ConstructObject5FromProto(GConstructObject5.fromJson(json));
+  String toJson(ConstructObject5 entity) =>
+      _$ConstructObject5ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject5 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject5 fromBase64Proto(String base64Proto) =>
+      GConstructObject5.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject5();
+}
+
+GConstructObject5 _$ConstructObject5ToProto(ConstructObject5 instance) {
+  var proto = GConstructObject5();
+
+  proto.name = instance.name;
+  proto.number = instance.number;
+
+  return proto;
+}
+
+ConstructObject5 _$ConstructObject5FromProto(GConstructObject5 instance) =>
+    ConstructObject5.name(
+      instance.name,
+      instance.number,
+    );
+
+extension $ConstructObject5ProtoExtension on ConstructObject5 {
+  GConstructObject5 toProto() => _$ConstructObject5ToProto(this);
+  String toJson() => _$ConstructObject5ToProto(this).writeToJson();
+
+  static ConstructObject5 fromProto(GConstructObject5 proto) =>
+      _$ConstructObject5FromProto(proto);
+  static ConstructObject5 fromJson(String json) =>
+      _$ConstructObject5FromProto(GConstructObject5.fromJson(json));
+}
+
+extension $GConstructObject5ProtoExtension on GConstructObject5 {
+  ConstructObject5 toConstructObject5() => _$ConstructObject5FromProto(this);
+}
+
+class $ConstructObject6ProtoMapper
+    implements ProtoMapper<ConstructObject6, GConstructObject6> {
+  const $ConstructObject6ProtoMapper();
+
+  @override
+  ConstructObject6 fromProto(GConstructObject6 proto) =>
+      _$ConstructObject6FromProto(proto);
+
+  @override
+  GConstructObject6 toProto(ConstructObject6 entity) =>
+      _$ConstructObject6ToProto(entity);
+
+  ConstructObject6 fromJson(String json) =>
+      _$ConstructObject6FromProto(GConstructObject6.fromJson(json));
+  String toJson(ConstructObject6 entity) =>
+      _$ConstructObject6ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject6 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject6 fromBase64Proto(String base64Proto) =>
+      GConstructObject6.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject6();
+}
+
+GConstructObject6 _$ConstructObject6ToProto(ConstructObject6 instance) {
+  var proto = GConstructObject6();
+
+  if (instance.name != null) {
+    proto.name = instance.name!;
+  }
+  proto.nameHasValue = instance.name != null;
+
+  if (instance.number != null) {
+    proto.number = instance.number!;
+  }
+  proto.numberHasValue = instance.number != null;
+
+  return proto;
+}
+
+ConstructObject6 _$ConstructObject6FromProto(GConstructObject6 instance) =>
+    ConstructObject6(
+      name: (instance.nameHasValue ? (instance.name) : null),
+    )..number = (instance.numberHasValue ? (instance.number) : null);
+
+extension $ConstructObject6ProtoExtension on ConstructObject6 {
+  GConstructObject6 toProto() => _$ConstructObject6ToProto(this);
+  String toJson() => _$ConstructObject6ToProto(this).writeToJson();
+
+  static ConstructObject6 fromProto(GConstructObject6 proto) =>
+      _$ConstructObject6FromProto(proto);
+  static ConstructObject6 fromJson(String json) =>
+      _$ConstructObject6FromProto(GConstructObject6.fromJson(json));
+}
+
+extension $GConstructObject6ProtoExtension on GConstructObject6 {
+  ConstructObject6 toConstructObject6() => _$ConstructObject6FromProto(this);
+}
+
+class $ConstructObject7ProtoMapper
+    implements ProtoMapper<ConstructObject7, GConstructObject7> {
+  const $ConstructObject7ProtoMapper();
+
+  @override
+  ConstructObject7 fromProto(GConstructObject7 proto) =>
+      _$ConstructObject7FromProto(proto);
+
+  @override
+  GConstructObject7 toProto(ConstructObject7 entity) =>
+      _$ConstructObject7ToProto(entity);
+
+  ConstructObject7 fromJson(String json) =>
+      _$ConstructObject7FromProto(GConstructObject7.fromJson(json));
+  String toJson(ConstructObject7 entity) =>
+      _$ConstructObject7ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject7 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject7 fromBase64Proto(String base64Proto) =>
+      GConstructObject7.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject7();
+}
+
+GConstructObject7 _$ConstructObject7ToProto(ConstructObject7 instance) {
+  var proto = GConstructObject7();
+
+  if (instance.number != null) {
+    proto.number = instance.number!;
+  }
+  proto.numberHasValue = instance.number != null;
+
+  proto.name = instance.name;
+
+  return proto;
+}
+
+ConstructObject7 _$ConstructObject7FromProto(GConstructObject7 instance) =>
+    ConstructObject7.name(
+      instance.name,
+      (instance.numberHasValue ? (instance.number) : null),
+    );
+
+extension $ConstructObject7ProtoExtension on ConstructObject7 {
+  GConstructObject7 toProto() => _$ConstructObject7ToProto(this);
+  String toJson() => _$ConstructObject7ToProto(this).writeToJson();
+
+  static ConstructObject7 fromProto(GConstructObject7 proto) =>
+      _$ConstructObject7FromProto(proto);
+  static ConstructObject7 fromJson(String json) =>
+      _$ConstructObject7FromProto(GConstructObject7.fromJson(json));
+}
+
+extension $GConstructObject7ProtoExtension on GConstructObject7 {
+  ConstructObject7 toConstructObject7() => _$ConstructObject7FromProto(this);
+}
+
+class $ConstructObject8ProtoMapper
+    implements ProtoMapper<ConstructObject8, GConstructObject8> {
+  const $ConstructObject8ProtoMapper();
+
+  @override
+  ConstructObject8 fromProto(GConstructObject8 proto) =>
+      _$ConstructObject8FromProto(proto);
+
+  @override
+  GConstructObject8 toProto(ConstructObject8 entity) =>
+      _$ConstructObject8ToProto(entity);
+
+  ConstructObject8 fromJson(String json) =>
+      _$ConstructObject8FromProto(GConstructObject8.fromJson(json));
+  String toJson(ConstructObject8 entity) =>
+      _$ConstructObject8ToProto(entity).writeToJson();
+
+  String toBase64Proto(ConstructObject8 entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  ConstructObject8 fromBase64Proto(String base64Proto) =>
+      GConstructObject8.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toConstructObject8();
+}
+
+GConstructObject8 _$ConstructObject8ToProto(ConstructObject8 instance) {
+  var proto = GConstructObject8();
+
+  if (instance.number != null) {
+    proto.number = instance.number!;
+  }
+  proto.numberHasValue = instance.number != null;
+
+  proto.name = instance.name;
+
+  return proto;
+}
+
+ConstructObject8 _$ConstructObject8FromProto(GConstructObject8 instance) =>
+    ConstructObject8.complete(
+      (instance.numberHasValue ? (instance.number) : null),
+      instance.name,
+    );
+
+extension $ConstructObject8ProtoExtension on ConstructObject8 {
+  GConstructObject8 toProto() => _$ConstructObject8ToProto(this);
+  String toJson() => _$ConstructObject8ToProto(this).writeToJson();
+
+  static ConstructObject8 fromProto(GConstructObject8 proto) =>
+      _$ConstructObject8FromProto(proto);
+  static ConstructObject8 fromJson(String json) =>
+      _$ConstructObject8FromProto(GConstructObject8.fromJson(json));
+}
+
+extension $GConstructObject8ProtoExtension on GConstructObject8 {
+  ConstructObject8 toConstructObject8() => _$ConstructObject8FromProto(this);
+}

--- a/proto_mapper/test/lib/src/utensils.dart
+++ b/proto_mapper/test/lib/src/utensils.dart
@@ -1,0 +1,64 @@
+import 'package:proto_annotations/proto_annotations.dart';
+import 'package:proto_generator_test/grpc/appliance_type.pbenum.dart';
+import 'package:proto_generator_test/grpc/utensils.pb.dart';
+
+import 'appliance_type.dart';
+import 'recipe.dart';
+
+part 'utensils.g.dart';
+
+@proto
+@mapProto
+enum KnifeType { chefsKnife, paringKnife, breadKnife }
+
+@proto
+@mapProto
+class Knife {
+  final String name;
+  final KnifeType type;
+
+  Knife({required this.name, required this.type});
+}
+
+@proto
+@mapProto
+class GarlicPress {
+  final String name;
+  final bool machineWashable;
+
+  GarlicPress({required this.name, required this.machineWashable});
+}
+
+@proto
+@mapProto
+class Kitchen {
+  final List<Recipe> recipeList;
+  final Map<String, Recipe> recipeMap;
+
+  const Kitchen({
+    required this.recipeList,
+    required this.recipeMap,
+  });
+}
+
+@proto
+@mapProto
+class Chef {
+  final Recipe favoriteRecipe;
+  final Knife favoriteKnife;
+  final ApplianceType favoriteApplianceType;
+
+  Chef({required this.favoriteRecipe, required this.favoriteKnife, required this.favoriteApplianceType});
+}
+
+@proto
+@mapProto
+class Inventory {
+  final Map<String, int> numberOfThings;
+  final Map<String, Recipe> recipesByName;
+
+  const Inventory({
+    required this.numberOfThings,
+    required this.recipesByName,
+  });
+}

--- a/proto_mapper/test/lib/src/utensils.dart
+++ b/proto_mapper/test/lib/src/utensils.dart
@@ -48,7 +48,10 @@ class Chef {
   final Knife favoriteKnife;
   final ApplianceType favoriteApplianceType;
 
-  Chef({required this.favoriteRecipe, required this.favoriteKnife, required this.favoriteApplianceType});
+  Chef(
+      {required this.favoriteRecipe,
+      required this.favoriteKnife,
+      required this.favoriteApplianceType});
 }
 
 @proto

--- a/proto_mapper/test/lib/src/utensils.g.dart
+++ b/proto_mapper/test/lib/src/utensils.g.dart
@@ -1,0 +1,272 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'utensils.dart';
+
+// **************************************************************************
+// ProtoMapperGenerator
+// **************************************************************************
+
+class $KnifeProtoMapper implements ProtoMapper<Knife, GKnife> {
+  const $KnifeProtoMapper();
+
+  @override
+  Knife fromProto(GKnife proto) => _$KnifeFromProto(proto);
+
+  @override
+  GKnife toProto(Knife entity) => _$KnifeToProto(entity);
+
+  Knife fromJson(String json) => _$KnifeFromProto(GKnife.fromJson(json));
+  String toJson(Knife entity) => _$KnifeToProto(entity).writeToJson();
+
+  String toBase64Proto(Knife entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  Knife fromBase64Proto(String base64Proto) =>
+      GKnife.fromJson(utf8.decode(base64Decode(base64Proto))).toKnife();
+}
+
+GKnife _$KnifeToProto(Knife instance) {
+  var proto = GKnife();
+
+  proto.name = instance.name;
+  proto.type = GKnifeType.valueOf(instance.type.index)!;
+
+  return proto;
+}
+
+Knife _$KnifeFromProto(GKnife instance) => Knife(
+      name: instance.name,
+      type: KnifeType.values[instance.type.value],
+    );
+
+extension $KnifeProtoExtension on Knife {
+  GKnife toProto() => _$KnifeToProto(this);
+  String toJson() => _$KnifeToProto(this).writeToJson();
+
+  static Knife fromProto(GKnife proto) => _$KnifeFromProto(proto);
+  static Knife fromJson(String json) => _$KnifeFromProto(GKnife.fromJson(json));
+}
+
+extension $GKnifeProtoExtension on GKnife {
+  Knife toKnife() => _$KnifeFromProto(this);
+}
+
+class $GarlicPressProtoMapper
+    implements ProtoMapper<GarlicPress, GGarlicPress> {
+  const $GarlicPressProtoMapper();
+
+  @override
+  GarlicPress fromProto(GGarlicPress proto) => _$GarlicPressFromProto(proto);
+
+  @override
+  GGarlicPress toProto(GarlicPress entity) => _$GarlicPressToProto(entity);
+
+  GarlicPress fromJson(String json) =>
+      _$GarlicPressFromProto(GGarlicPress.fromJson(json));
+  String toJson(GarlicPress entity) =>
+      _$GarlicPressToProto(entity).writeToJson();
+
+  String toBase64Proto(GarlicPress entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  GarlicPress fromBase64Proto(String base64Proto) =>
+      GGarlicPress.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toGarlicPress();
+}
+
+GGarlicPress _$GarlicPressToProto(GarlicPress instance) {
+  var proto = GGarlicPress();
+
+  proto.name = instance.name;
+  proto.machineWashable = instance.machineWashable;
+
+  return proto;
+}
+
+GarlicPress _$GarlicPressFromProto(GGarlicPress instance) => GarlicPress(
+      name: instance.name,
+      machineWashable: instance.machineWashable,
+    );
+
+extension $GarlicPressProtoExtension on GarlicPress {
+  GGarlicPress toProto() => _$GarlicPressToProto(this);
+  String toJson() => _$GarlicPressToProto(this).writeToJson();
+
+  static GarlicPress fromProto(GGarlicPress proto) =>
+      _$GarlicPressFromProto(proto);
+  static GarlicPress fromJson(String json) =>
+      _$GarlicPressFromProto(GGarlicPress.fromJson(json));
+}
+
+extension $GGarlicPressProtoExtension on GGarlicPress {
+  GarlicPress toGarlicPress() => _$GarlicPressFromProto(this);
+}
+
+class $KitchenProtoMapper implements ProtoMapper<Kitchen, GKitchen> {
+  const $KitchenProtoMapper();
+
+  @override
+  Kitchen fromProto(GKitchen proto) => _$KitchenFromProto(proto);
+
+  @override
+  GKitchen toProto(Kitchen entity) => _$KitchenToProto(entity);
+
+  Kitchen fromJson(String json) => _$KitchenFromProto(GKitchen.fromJson(json));
+  String toJson(Kitchen entity) => _$KitchenToProto(entity).writeToJson();
+
+  String toBase64Proto(Kitchen entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  Kitchen fromBase64Proto(String base64Proto) =>
+      GKitchen.fromJson(utf8.decode(base64Decode(base64Proto))).toKitchen();
+}
+
+GKitchen _$KitchenToProto(Kitchen instance) {
+  var proto = GKitchen();
+
+  proto.recipeList.addAll(
+      instance.recipeList.map((e) => const $RecipeProtoMapper().toProto(e)));
+
+  proto.recipeMap.addAll(instance.recipeMap
+      .map((k, v) => MapEntry(k, const $RecipeProtoMapper().toProto(v))));
+
+  return proto;
+}
+
+Kitchen _$KitchenFromProto(GKitchen instance) => Kitchen(
+      recipeList: List<Recipe>.unmodifiable(instance.recipeList
+          .map((e) => const $RecipeProtoMapper().fromProto(e))),
+      recipeMap: instance.recipeMap
+          .map((k, v) => MapEntry(k, const $RecipeProtoMapper().fromProto(v))),
+    );
+
+extension $KitchenProtoExtension on Kitchen {
+  GKitchen toProto() => _$KitchenToProto(this);
+  String toJson() => _$KitchenToProto(this).writeToJson();
+
+  static Kitchen fromProto(GKitchen proto) => _$KitchenFromProto(proto);
+  static Kitchen fromJson(String json) =>
+      _$KitchenFromProto(GKitchen.fromJson(json));
+}
+
+extension $GKitchenProtoExtension on GKitchen {
+  Kitchen toKitchen() => _$KitchenFromProto(this);
+}
+
+class $ChefProtoMapper implements ProtoMapper<Chef, GChef> {
+  const $ChefProtoMapper();
+
+  @override
+  Chef fromProto(GChef proto) => _$ChefFromProto(proto);
+
+  @override
+  GChef toProto(Chef entity) => _$ChefToProto(entity);
+
+  Chef fromJson(String json) => _$ChefFromProto(GChef.fromJson(json));
+  String toJson(Chef entity) => _$ChefToProto(entity).writeToJson();
+
+  String toBase64Proto(Chef entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  Chef fromBase64Proto(String base64Proto) =>
+      GChef.fromJson(utf8.decode(base64Decode(base64Proto))).toChef();
+}
+
+GChef _$ChefToProto(Chef instance) {
+  var proto = GChef();
+
+  proto.favoriteRecipe =
+      const $RecipeProtoMapper().toProto(instance.favoriteRecipe);
+  proto.favoriteKnife =
+      const $KnifeProtoMapper().toProto(instance.favoriteKnife);
+  proto.favoriteApplianceType =
+      GApplianceType.valueOf(instance.favoriteApplianceType.index)!;
+
+  return proto;
+}
+
+Chef _$ChefFromProto(GChef instance) => Chef(
+      favoriteRecipe:
+          const $RecipeProtoMapper().fromProto(instance.favoriteRecipe),
+      favoriteKnife:
+          const $KnifeProtoMapper().fromProto(instance.favoriteKnife),
+      favoriteApplianceType:
+          ApplianceType.values[instance.favoriteApplianceType.value],
+    );
+
+extension $ChefProtoExtension on Chef {
+  GChef toProto() => _$ChefToProto(this);
+  String toJson() => _$ChefToProto(this).writeToJson();
+
+  static Chef fromProto(GChef proto) => _$ChefFromProto(proto);
+  static Chef fromJson(String json) => _$ChefFromProto(GChef.fromJson(json));
+}
+
+extension $GChefProtoExtension on GChef {
+  Chef toChef() => _$ChefFromProto(this);
+}
+
+class $InventoryProtoMapper implements ProtoMapper<Inventory, GInventory> {
+  const $InventoryProtoMapper();
+
+  @override
+  Inventory fromProto(GInventory proto) => _$InventoryFromProto(proto);
+
+  @override
+  GInventory toProto(Inventory entity) => _$InventoryToProto(entity);
+
+  Inventory fromJson(String json) =>
+      _$InventoryFromProto(GInventory.fromJson(json));
+  String toJson(Inventory entity) => _$InventoryToProto(entity).writeToJson();
+
+  String toBase64Proto(Inventory entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  Inventory fromBase64Proto(String base64Proto) =>
+      GInventory.fromJson(utf8.decode(base64Decode(base64Proto))).toInventory();
+}
+
+GInventory _$InventoryToProto(Inventory instance) {
+  var proto = GInventory();
+
+  proto.numberOfThings
+      .addAll(instance.numberOfThings.map((k, v) => MapEntry(k, v)));
+
+  proto.recipesByName.addAll(instance.recipesByName
+      .map((k, v) => MapEntry(k, const $RecipeProtoMapper().toProto(v))));
+
+  return proto;
+}
+
+Inventory _$InventoryFromProto(GInventory instance) => Inventory(
+      numberOfThings: instance.numberOfThings.map((k, v) => MapEntry(k, v)),
+      recipesByName: instance.recipesByName
+          .map((k, v) => MapEntry(k, const $RecipeProtoMapper().fromProto(v))),
+    );
+
+extension $InventoryProtoExtension on Inventory {
+  GInventory toProto() => _$InventoryToProto(this);
+  String toJson() => _$InventoryToProto(this).writeToJson();
+
+  static Inventory fromProto(GInventory proto) => _$InventoryFromProto(proto);
+  static Inventory fromJson(String json) =>
+      _$InventoryFromProto(GInventory.fromJson(json));
+}
+
+extension $GInventoryProtoExtension on GInventory {
+  Inventory toInventory() => _$InventoryFromProto(this);
+}
+
+class $KnifeTypeProtoMapper implements ProtoMapper<KnifeType, GKnifeType> {
+  const $KnifeTypeProtoMapper();
+
+  @override
+  KnifeType fromProto(GKnifeType proto) => KnifeType.values[proto.value];
+
+  @override
+  GKnifeType toProto(KnifeType entity) => GKnifeType.valueOf(entity.index)!;
+}
+
+extension $GKnifeTypeProtoExtension on GKnifeType {
+  KnifeType toKnifeType() => const $KnifeTypeProtoMapper().fromProto(this);
+}

--- a/proto_mapper/test/proto/constructors_host.proto
+++ b/proto_mapper/test/proto/constructors_host.proto
@@ -1,0 +1,102 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// ProtoGenerator
+// **************************************************************************
+
+syntax = "proto3";
+
+
+
+
+message GConstructObject1
+{
+  string name = 1;
+  int32 number = 2;
+}   
+
+message GListOfConstructObject1
+{
+  repeated GConstructObject1 items = 1;
+}
+
+message GConstructObject2
+{
+  string name = 1;
+  int32 number = 2;
+}   
+
+message GListOfConstructObject2
+{
+  repeated GConstructObject2 items = 1;
+}
+
+message GConstructObject3
+{
+  string name = 1;
+  int32 number = 2;
+}   
+
+message GListOfConstructObject3
+{
+  repeated GConstructObject3 items = 1;
+}
+
+message GConstructObject4
+{
+  string name = 1;
+  int32 number = 2;
+}   
+
+message GListOfConstructObject4
+{
+  repeated GConstructObject4 items = 1;
+}
+
+message GConstructObject5
+{
+  string name = 1;
+  int32 number = 2;
+}   
+
+message GListOfConstructObject5
+{
+  repeated GConstructObject5 items = 1;
+}
+
+message GConstructObject6
+{
+  string name = 1;
+  bool nameHasValue = 2;
+  int32 number = 3;
+  bool numberHasValue = 4;
+}   
+
+message GListOfConstructObject6
+{
+  repeated GConstructObject6 items = 1;
+}
+
+message GConstructObject7
+{
+  int32 number = 1;
+  bool numberHasValue = 2;
+  string name = 3;
+}   
+
+message GListOfConstructObject7
+{
+  repeated GConstructObject7 items = 1;
+}
+
+message GConstructObject8
+{
+  int32 number = 1;
+  bool numberHasValue = 2;
+  string name = 3;
+}   
+
+message GListOfConstructObject8
+{
+  repeated GConstructObject8 items = 1;
+}

--- a/proto_mapper/test/proto/utensils.proto
+++ b/proto_mapper/test/proto/utensils.proto
@@ -1,0 +1,89 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// ProtoGenerator
+// **************************************************************************
+
+syntax = "proto3";
+
+
+
+
+message GKnife
+{
+  string name = 1;
+  GKnifeType type = 2;
+}   
+
+message GListOfKnife
+{
+  repeated GKnife items = 1;
+}
+
+message GGarlicPress
+{
+  string name = 1;
+  bool machineWashable = 2;
+}   
+
+message GListOfGarlicPress
+{
+  repeated GGarlicPress items = 1;
+}
+
+import 'recipe.proto';
+
+
+
+
+message GKitchen
+{
+  repeated GRecipe recipeList = 1;
+  map<string, GRecipe> recipeMap = 2;
+}   
+
+message GListOfKitchen
+{
+  repeated GKitchen items = 1;
+}
+
+import 'appliance_type.proto';
+
+
+
+
+message GChef
+{
+  GRecipe favoriteRecipe = 1;
+  GKnife favoriteKnife = 2;
+  GApplianceType favoriteApplianceType = 3;
+}   
+
+message GListOfChef
+{
+  repeated GChef items = 1;
+}
+
+message GInventory
+{
+  map<string, int32> numberOfThings = 1;
+  map<string, GRecipe> recipesByName = 2;
+}   
+
+message GListOfInventory
+{
+  repeated GInventory items = 1;
+}
+
+enum GKnifeType
+{
+  chefsKnife = 0;
+  paringKnife = 1;
+  breadKnife = 2;
+}   
+     
+message NullableGKnifeType
+{
+  bool hasValue = 1;
+  GKnifeType value = 2;
+}

--- a/proto_mapper/test/test/constructors_test.dart
+++ b/proto_mapper/test/test/constructors_test.dart
@@ -1,14 +1,12 @@
-import 'package:decimal/decimal.dart';
-import 'package:proto_generator_test/src/appliance_type.dart';
 import 'package:proto_generator_test/src/constructors_host.dart';
-import 'package:proto_generator_test/src/lists_host.dart';
 import 'package:test/test.dart';
 
 void main() {
-
   group('Constructors', () {
     test('Two late properties, default constructor', () {
-      final construct = ConstructObject1()..name = 'Test'..number = 1;
+      final construct = ConstructObject1()
+        ..name = 'Test'
+        ..number = 1;
       final proto = construct.toProto();
       final proto2 = proto.toConstructObject1();
       expect(proto2, construct);
@@ -23,7 +21,9 @@ void main() {
       expect(proto2.name, construct.name);
       expect(proto2.number, construct.number);
     });
-    test('Unnamed constructor with unnamed arg, one missing but set by constructor', () {
+    test(
+        'Unnamed constructor with unnamed arg, one missing but set by constructor',
+        () {
       final construct = ConstructObject3('Test')..number = 1;
       final proto = construct.toProto();
       final proto2 = proto.toConstructObject3();
@@ -31,7 +31,8 @@ void main() {
       expect(proto2.name, construct.name);
       expect(proto2.number, construct.number);
     });
-    test('Only one named constructor arg, one missing but set by constructor', () {
+    test('Only one named constructor arg, one missing but set by constructor',
+        () {
       final construct = ConstructObject4(name: 'Test')..number = 1;
       final proto = construct.toProto();
       final proto2 = proto.toConstructObject4();
@@ -55,7 +56,9 @@ void main() {
       expect(proto2.name, construct.name);
       expect(proto2.number, construct.number);
     });
-    test('Named constructor, unnammed arguments, different order for fields and arguments', () {
+    test(
+        'Named constructor, unnammed arguments, different order for fields and arguments',
+        () {
       final construct = ConstructObject7.name('Test', 1);
       final proto = construct.toProto();
       final proto2 = proto.toConstructObject7();
@@ -71,6 +74,5 @@ void main() {
       expect(proto2.name, construct.name);
       expect(proto2.number, construct.number);
     });
-
   });
 }

--- a/proto_mapper/test/test/constructors_test.dart
+++ b/proto_mapper/test/test/constructors_test.dart
@@ -1,0 +1,76 @@
+import 'package:decimal/decimal.dart';
+import 'package:proto_generator_test/src/appliance_type.dart';
+import 'package:proto_generator_test/src/constructors_host.dart';
+import 'package:proto_generator_test/src/lists_host.dart';
+import 'package:test/test.dart';
+
+void main() {
+
+  group('Constructors', () {
+    test('Two late properties, default constructor', () {
+      final construct = ConstructObject1()..name = 'Test'..number = 1;
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject1();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Unnamed constructor with both (required) args present', () {
+      final construct = ConstructObject2('Test', 2);
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject2();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Unnamed constructor with unnamed arg, one missing but set by constructor', () {
+      final construct = ConstructObject3('Test')..number = 1;
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject3();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Only one named constructor arg, one missing but set by constructor', () {
+      final construct = ConstructObject4(name: 'Test')..number = 1;
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject4();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Named constructor with unnammed arguments', () {
+      final construct = ConstructObject5.name('Test', 1);
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject5();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Unnamed constructor, one named optional argument', () {
+      final construct = ConstructObject6(name: 'Test')..number = 1;
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject6();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Named constructor, unnammed arguments, different order for fields and arguments', () {
+      final construct = ConstructObject7.name('Test', 1);
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject7();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+    test('Multiple constructors, only one that covers all the fields', () {
+      final construct = ConstructObject8.incomplete('Test');
+      final proto = construct.toProto();
+      final proto2 = proto.toConstructObject8();
+      expect(proto2, construct);
+      expect(proto2.name, construct.name);
+      expect(proto2.number, construct.number);
+    });
+
+  });
+}

--- a/proto_mapper/test/test/imports_test.dart
+++ b/proto_mapper/test/test/imports_test.dart
@@ -1,0 +1,45 @@
+import 'package:proto_generator_test/proto_generator_test.dart';
+import 'package:proto_generator_test/src/appliance_type.dart';
+import 'package:proto_generator_test/src/component.dart';
+import 'package:proto_generator_test/src/utensils.dart';
+import 'package:proto_generator_test/grpc/utensils.pb.dart';
+import 'package:proto_generator_test/grpc/recipe.pb.dart';
+import 'package:test/test.dart';
+
+/// With the classes defined in "utensils.proto", we can test the following items implicitly,
+/// as building and generating code without errors should prove the following:
+///  - multiple @proto and @mapProto annotations can live within the same .dart file
+///  - duplicate "import" and "syntax" statements are filtered out
+///  - .proto files will not import itself
+void main() {
+  group('Imports', () {
+    test('utensil', () {
+      final kitchen = _kitchen();
+      expect(kitchen.toJson(), equals(kitchen.toProto().toKitchen().toJson()));
+
+    });
+  });
+}
+
+Kitchen _kitchen() {
+  return Kitchen(
+    recipeList: [_recipe()],
+    recipeMap: {
+      'test1': _recipe(),
+      'test2': _recipe(),
+      'test3': _recipe(),
+    },
+  );
+}
+
+Recipe _recipe() {
+  return Recipe(
+      title: 'Recipe 1',
+      category: Category(title: 'Category', mainComponent: Component(description: 'Description'), otherComponents: []),
+      ingredients: [],
+      publishDate: DateTime.now(),
+      preparationDuration: Duration(),
+      isPublished: true,
+      mainApplianceType: ApplianceType.cold,
+      tags: []);
+}

--- a/proto_mapper/test/test/imports_test.dart
+++ b/proto_mapper/test/test/imports_test.dart
@@ -2,8 +2,6 @@ import 'package:proto_generator_test/proto_generator_test.dart';
 import 'package:proto_generator_test/src/appliance_type.dart';
 import 'package:proto_generator_test/src/component.dart';
 import 'package:proto_generator_test/src/utensils.dart';
-import 'package:proto_generator_test/grpc/utensils.pb.dart';
-import 'package:proto_generator_test/grpc/recipe.pb.dart';
 import 'package:test/test.dart';
 
 /// With the classes defined in "utensils.proto", we can test the following items implicitly,
@@ -16,7 +14,6 @@ void main() {
     test('utensil', () {
       final kitchen = _kitchen();
       expect(kitchen.toJson(), equals(kitchen.toProto().toKitchen().toJson()));
-
     });
   });
 }
@@ -35,7 +32,10 @@ Kitchen _kitchen() {
 Recipe _recipe() {
   return Recipe(
       title: 'Recipe 1',
-      category: Category(title: 'Category', mainComponent: Component(description: 'Description'), otherComponents: []),
+      category: Category(
+          title: 'Category',
+          mainComponent: Component(description: 'Description'),
+          otherComponents: []),
       ingredients: [],
       publishDate: DateTime.now(),
       preparationDuration: Duration(),

--- a/proto_mapper/test/test/maps_test.dart
+++ b/proto_mapper/test/test/maps_test.dart
@@ -24,8 +24,10 @@ void main() {
       var deserializedJson = GInventory.fromJson(serialized).toInventory();
       var deserializedProto = proto.toInventory();
       expect(inventory.toProto().writeToJson(), equals(serialized));
-      expect(inventory.toProto().writeToJson(), equals(deserializedJson.toJson()));
-      expect(inventory.toProto().writeToJson(), equals(deserializedProto.toJson()));
+      expect(
+          inventory.toProto().writeToJson(), equals(deserializedJson.toJson()));
+      expect(inventory.toProto().writeToJson(),
+          equals(deserializedProto.toJson()));
       print(inventory.toJson());
     });
   });
@@ -37,16 +39,16 @@ Inventory _inventory() {
     "One": 1,
     "Two": 2,
     "Three": 3
-  // }, numberOfKnives: {
-  //   Knife(name: "Chef's", type: KnifeType.chefsKnife): 2,
-  //   Knife(name: "Bread", type: KnifeType.breadKnife): 1
+    // }, numberOfKnives: {
+    //   Knife(name: "Chef's", type: KnifeType.chefsKnife): 2,
+    //   Knife(name: "Bread", type: KnifeType.breadKnife): 1
   }, recipesByName: {
     "Lasagna": lasagnaRecipe
-  // }, knifePerRecipe: {
-  //   lasagnaRecipe: Knife(name: 'Lasagna Knife', type: KnifeType.paringKnife)
-  // }, applianceKnifeMap: {
-  //   ApplianceType.heat: Knife(name: "Hot Knife", type: KnifeType.chefsKnife),
-  //   ApplianceType.cold: Knife(name: "Cold Knife", type: KnifeType.chefsKnife)
+    // }, knifePerRecipe: {
+    //   lasagnaRecipe: Knife(name: 'Lasagna Knife', type: KnifeType.paringKnife)
+    // }, applianceKnifeMap: {
+    //   ApplianceType.heat: Knife(name: "Hot Knife", type: KnifeType.chefsKnife),
+    //   ApplianceType.cold: Knife(name: "Cold Knife", type: KnifeType.chefsKnife)
   });
   return inventory;
 }
@@ -54,7 +56,10 @@ Inventory _inventory() {
 Recipe _recipe() {
   var lasagnaRecipe = Recipe(
       title: "Lasagna",
-      category: Category(title: "Sauce", mainComponent: Component(description: "Red sauce"), otherComponents: []),
+      category: Category(
+          title: "Sauce",
+          mainComponent: Component(description: "Red sauce"),
+          otherComponents: []),
       ingredients: [
         Ingredient(
             description: "Tomatoes",

--- a/proto_mapper/test/test/maps_test.dart
+++ b/proto_mapper/test/test/maps_test.dart
@@ -1,0 +1,73 @@
+import 'package:decimal/decimal.dart';
+import 'package:proto_generator_test/grpc/utensils.pb.dart';
+import 'package:proto_generator_test/proto_generator_test.dart';
+import 'package:proto_generator_test/src/appliance_type.dart';
+import 'package:proto_generator_test/src/component.dart';
+import 'package:proto_generator_test/src/utensils.dart';
+import 'package:test/test.dart';
+
+/// Test support for different types of maps.
+/// Protobuf only supports certain primitive/primitive or primitive/non-primitive key/value type pairs.
+///   Some error messages when making other combinations:
+///     Key in map fields cannot be float/double, bytes or message types.
+///     Key in map fields cannot be enum types.
+///
+/// The "utensils.dart" file also implicitly tests some other things:
+///   -
+///
+void main() {
+  group('Maps', () {
+    test('Inventory maps', () {
+      var inventory = _inventory();
+      var proto = inventory.toProto();
+      var serialized = inventory.toJson();
+      var deserializedJson = GInventory.fromJson(serialized).toInventory();
+      var deserializedProto = proto.toInventory();
+      expect(inventory.toProto().writeToJson(), equals(serialized));
+      expect(inventory.toProto().writeToJson(), equals(deserializedJson.toJson()));
+      expect(inventory.toProto().writeToJson(), equals(deserializedProto.toJson()));
+      print(inventory.toJson());
+    });
+  });
+}
+
+Inventory _inventory() {
+  Recipe lasagnaRecipe = _recipe();
+  final inventory = Inventory(numberOfThings: {
+    "One": 1,
+    "Two": 2,
+    "Three": 3
+  // }, numberOfKnives: {
+  //   Knife(name: "Chef's", type: KnifeType.chefsKnife): 2,
+  //   Knife(name: "Bread", type: KnifeType.breadKnife): 1
+  }, recipesByName: {
+    "Lasagna": lasagnaRecipe
+  // }, knifePerRecipe: {
+  //   lasagnaRecipe: Knife(name: 'Lasagna Knife', type: KnifeType.paringKnife)
+  // }, applianceKnifeMap: {
+  //   ApplianceType.heat: Knife(name: "Hot Knife", type: KnifeType.chefsKnife),
+  //   ApplianceType.cold: Knife(name: "Cold Knife", type: KnifeType.chefsKnife)
+  });
+  return inventory;
+}
+
+Recipe _recipe() {
+  var lasagnaRecipe = Recipe(
+      title: "Lasagna",
+      category: Category(title: "Sauce", mainComponent: Component(description: "Red sauce"), otherComponents: []),
+      ingredients: [
+        Ingredient(
+            description: "Tomatoes",
+            quantity: Decimal.ten,
+            precision: 1.2,
+            cookingDuration: Duration(minutes: 5),
+            mainComponent: Component(description: "Red sauce"),
+            otherComponents: [])
+      ],
+      publishDate: DateTime.now(),
+      preparationDuration: Duration(days: 10),
+      isPublished: false,
+      mainApplianceType: ApplianceType.heat,
+      tags: []);
+  return lasagnaRecipe;
+}


### PR DESCRIPTION
I had a couple of issues with the proto_generator package, of which the following should be fixed with this PR:
 - Using ``@proto`` or ``@mapProto`` on multiple classes within a single ``.dart`` would give multiple ``syntax`` and duplicate ``import`` statements in the generated ``.proto`` file
 - Maps are not supported, while **protobuf** does seem to support maps (in a limited way)
 - Constructor calls in generated ``FromProto()`` methods were a bit naive...

I'm not sure if I followed all of the required coding conventions, feel free adjust things to match internal policies. If this PR can be merged, then the package would become more or less usable for me.

There are some other issues I'll be looking into, but not sure when I'll have time to address those. In the meanwhile, I'm hoping this could already be reviewed.