### PR TITLE
Map dynamic fields / collection values to "google.protobuf.Any" fields

### DIFF
--- a/proto_mapper/proto_generator/CHANGELOG.md
+++ b/proto_mapper/proto_generator/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 3.0.3
+- Added support for `dynamic` or `Object` typed field and collection values. These are being mapped to `google.protobuf.Any` fields in the `.proto` files.
+
 ## 3.0.2
-- Use double instead of single quotes for import statements in `.proto`  files
+
+- Use double instead of single quotes for import statements in `.proto` files
 
 ## 3.0.1
 - Updated dependencies

--- a/proto_mapper/proto_generator/README.md
+++ b/proto_mapper/proto_generator/README.md
@@ -22,6 +22,27 @@ We begin by typing our business model. The next step is to use the proto_generat
 
 In order to get started, look at the example project at https://github.com/squarealfa/dart_framework/tree/main/proto_mapper/example.
 
+### Using Map\<?, ?> types in @proto/@mapProto annotated classes
+It is possible to make use of Map types, but only when adhering to the following rules:
+ - keys should be primitive values (ie: String, int, ... )
+ - values can be primitives or objects, but not a collection type
+
+See https://developers.google.com/protocol-buffers/docs/proto3#maps for more information regarding the limits of Maps in protocol buffers. 
+
+### Making use of dynamic values
+`dynamic` and `Object` typed fields or collection values are also supported. 
+In the `.proto` files, these translate into `google.protobuf.Any` fields.
+In the generated mappers, they'll be "packed" and "unpacked" using the `Any` class/extension.
+
+Please note that in order to actually use this, you'll have to set up the following:
+ - The `any.proto` file needs to be available when running `protoc`. This can be done by adding `-I%PROTOC_HOME%/include` to the `protoc` command, where `%PROTOC_HOME` points to the location of your **protoc** installation.
+ - The `any.pb[enum|json|server].dart` files need to be generated and added to the `lib/grpc` folder.
+    ```
+     cd ./dart_framework/proto_mapper/test
+     protoc --dart_out=grpc:lib/grpc -I%PROTOC_HOME%/include %PROTOC_HOME%/include/google/protobuf/any.proto
+    ```
+
+See https://developers.google.com/protocol-buffers/docs/proto3#any for more information.
 
 ## Context
 

--- a/proto_mapper/proto_generator/build.yaml
+++ b/proto_mapper/proto_generator/build.yaml
@@ -9,6 +9,13 @@ builders:
     build_to: cache
     applies_builders: ["source_gen|combining_builder"]
 
+  proto_dynamic_mapper_generator:
+    import: "package:proto_generator/proto_generator.dart"
+    builder_factories: ["protoDynamicMapperBuilder"]
+    build_extensions: {}
+    auto_apply: dependents
+    build_to: source
+
   proto_generator:
     import: "package:proto_generator/proto_generator.dart"
     builder_factories: ["protoBuilder"]

--- a/proto_mapper/proto_generator/lib/proto_generator.dart
+++ b/proto_mapper/proto_generator/lib/proto_generator.dart
@@ -4,7 +4,9 @@
 library proto_generator;
 
 import 'package:build/build.dart';
+// import 'package:code_builder/code_builder.dart';
 import 'package:proto_generator/src/proto/proto_generator.dart';
+import 'package:proto_generator/src/proto_dynamic_mapper/proto_dynamic_mapper_generator.dart';
 import 'package:proto_generator/src/proto_mapper/proto_mapper_generator.dart';
 import 'package:proto_generator/src/proto_services/proto_services_generator.dart';
 import 'package:proto_generator/src/proto_services_mapper/proto_services_client_generator.dart';
@@ -16,6 +18,9 @@ export 'src/proto_mapper/proto_mapper_generator.dart';
 
 Builder protoMapperBuilder(BuilderOptions options) =>
     SharedPartBuilder([ProtoMapperGenerator(options)], 'proto_map');
+
+Builder protoDynamicMapperBuilder(BuilderOptions options) =>
+    ProtoDynamicMapperBuilder(options);
 
 Builder protoBuilder(BuilderOptions options) =>
     LibraryBuilder(ProtoGenerator(options),

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generator.dart
@@ -1,3 +1,4 @@
+import 'package:proto_generator/src/proto/field_code_generators/dynamic_field_code_generator.dart';
 import 'package:proto_generator/src/proto_common.dart';
 
 import 'field_code_generators/bool_field_code_generator.dart';
@@ -69,6 +70,9 @@ abstract class FieldCodeGenerator {
     if (type.isDartCoreMap) {
       return MapFieldCodeGenerator(fieldDescriptor, lineNumbers);
     }
+    if (_hasDynamicValue(fieldDescriptor)) {
+      return DynamicFieldCodeGenerator(fieldDescriptor, lineNumbers);
+    }
     return GenericFieldCodeGenerator(fieldDescriptor, lineNumbers);
   }
 }
@@ -78,4 +82,12 @@ int _nextAvailable(List<int> numbers) {
   while (numbers.contains(++i)) {}
   numbers.add(i);
   return i;
+}
+
+bool _hasDynamicValue(FieldDescriptor fieldDescriptor) {
+  return fieldDescriptor.fieldElementType.isDynamic ||
+      fieldDescriptor.fieldElementType.isDartCoreObject ||
+      (fieldDescriptor.isRepeated &&
+          (fieldDescriptor.parameterType.isDynamic ||
+              fieldDescriptor.parameterType.isDartCoreObject));
 }

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/dynamic_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/dynamic_field_code_generator.dart
@@ -1,0 +1,10 @@
+import '../field_code_generator.dart';
+import '../field_descriptor.dart';
+
+class DynamicFieldCodeGenerator extends FieldCodeGenerator {
+  DynamicFieldCodeGenerator(FieldDescriptor fieldDescriptor, List<int> lineNumbers)
+      : super(fieldDescriptor, lineNumbers);
+
+  @override
+  String get fieldType => 'google.protobuf.Any';
+}

--- a/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto/field_code_generators/map_field_code_generator.dart
@@ -41,6 +41,10 @@ class MapFieldCodeGenerator extends FieldCodeGenerator
           argumentType.isDartCoreBool) {
         continue;
       }
+      if (argumentType.isDynamic || argumentType.isDartCoreObject) {
+        names.add('google/protobuf/any.proto');
+        continue;
+      }
       final segments = argumentType.element!.source!.uri.pathSegments.toList();
       final lastSrc = segments.lastIndexOf('src');
       if (lastSrc != -1) segments.removeRange(0, lastSrc + 1);
@@ -69,6 +73,8 @@ class MapFieldCodeGenerator extends FieldCodeGenerator
       return 'int64';
     } else if (keyType.isDartCoreBool) {
       return 'bool';
+    } else if (keyType.isDynamic || keyType.isDartCoreObject) {
+      return 'google.protobuf.Any';
     }
     return '$prefix${keyType.getDisplayString(withNullability: true)}';
   }

--- a/proto_mapper/proto_generator/lib/src/proto_common.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_common.dart
@@ -132,6 +132,9 @@ String collectionProtoToValue(mapperfield.FieldDescriptor fieldDescriptor,
     }
     return 'Duration(milliseconds: $parameterName.toInt())';
   }
+  if (_hasDynamicValue(fieldDescriptor)) {
+    return ''' DynamicProtoMapper.fromProto($parameterName)''';
+  }
   return ''' const \$${fieldTypeName}ProtoMapper().fromProto($parameterName)''';
 }
 
@@ -153,5 +156,17 @@ String collectionValueToProto(mapperfield.FieldDescriptor fieldDescriptor,
     }
     return '$parameterName.inMilliseconds.toDouble()';
   }
+  if (_hasDynamicValue(fieldDescriptor)) {
+    return ''' DynamicProtoMapper.toProto($parameterName)''';
+  }
   return ''' const \$${fieldTypeName}ProtoMapper().toProto($parameterName)''';
+}
+
+bool _hasDynamicValue(mapperfield.FieldDescriptor fieldDescriptor) {
+  return ((fieldDescriptor.fieldElementType.isDartCoreList || fieldDescriptor.fieldElementType.isDartCoreSet) &&
+    (fieldDescriptor.parameterType.isDynamic || fieldDescriptor.parameterType.isDartCoreObject)) ||
+    (fieldDescriptor.fieldElementType.isDartCoreMap && (
+        ((fieldDescriptor.fieldElementType as InterfaceType).typeArguments[1].isDynamic ||
+            (fieldDescriptor.fieldElementType as InterfaceType).typeArguments[1].isDartCoreObject))
+    );
 }

--- a/proto_mapper/proto_generator/lib/src/proto_dynamic_mapper/proto_dynamic_mapper_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_dynamic_mapper/proto_dynamic_mapper_generator.dart
@@ -1,0 +1,223 @@
+import 'dart:async';
+
+import 'package:analyzer/dart/element/element.dart';
+import 'package:build/build.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:glob/glob.dart';
+import 'package:path/path.dart' as p;
+import 'package:proto_annotations/proto_annotations.dart';
+import 'package:source_gen/source_gen.dart' as sg;
+
+import 'package:code_builder/code_builder.dart';
+
+class ProtoDynamicMapperBuilder implements Builder {
+  static final _allFilesInLib = Glob('lib/**');
+
+  final anyRef = const Reference('Any');
+
+  final typeChecker = sg.TypeChecker.fromRuntime(MapProto);
+
+  final bool _enabled;
+  final String _typeUrlPrefix;
+  final String _generatedPrefix;
+  final String _generatedPbFolder;
+
+  ProtoDynamicMapperBuilder(BuilderOptions options):
+    _enabled = options.config['enabled'] as bool? ?? false,
+    _typeUrlPrefix = options.config['typeUrlPrefix'] as String? ?? 'type.googleapis.com',
+    _generatedPrefix = options.config['generatedPrefix'] as String? ?? 'G',
+    _generatedPbFolder = options.config['generatedProtobufFolder'] as String? ?? '../grpc';
+
+  @override
+  FutureOr<void> build(BuildStep buildStep) async {
+    if (!_enabled) {
+      return;
+    }
+    List<ClassElement> mappedClasses = await _getMapProtoClasses(buildStep);
+    final importedLibraries = <String>{};
+    // TODO: look up these imports dynamically?
+    importedLibraries.add('dart:convert');
+    importedLibraries.add('dart:math');
+    importedLibraries.add('dart:typed_data');
+    importedLibraries.add('package:decimal/decimal.dart');
+    importedLibraries.add('package:protobuf/protobuf.dart');
+    importedLibraries.add('$_generatedPbFolder/google/protobuf/any.pb.dart');
+
+    final typeRegistry = FieldBuilder()
+    ..name = 'typeRegistry'
+    ..type = Reference('TypeRegistry')
+    ..static = true
+    ..modifier = FieldModifier.final$
+    ..assignment = Code('TypeRegistry([${mappedClasses.where((c) => !c.isEnum).map((c) => '$_generatedPrefix${c.name}()').join(',')}])');
+
+    // fromProto() method
+    final fromProtoBuilder = MethodBuilder()
+      ..name = 'fromProto'
+      ..returns = const Reference('dynamic')
+      ..requiredParameters.add((ParameterBuilder()
+            ..name = 'proto'
+            ..type = anyRef)
+          .build())
+      ..static = true
+      ..body = _fromProto(importedLibraries, mappedClasses);
+
+    // toProto() method
+    final toProtoBuilder = MethodBuilder()
+      ..name = 'toProto'
+      ..returns = anyRef
+      ..requiredParameters.add((ParameterBuilder()
+            ..name = 'value'
+            ..type = const Reference('dynamic'))
+          .build())
+      ..static = true
+      ..body = _toProto(importedLibraries, mappedClasses);
+
+    // DynamicProtoMapper class
+    final mapperBuilder = ClassBuilder()
+      ..name = 'DynamicProtoMapper'
+      ..fields.add(typeRegistry.build())
+      ..methods.addAll([fromProtoBuilder.build(), toProtoBuilder.build()])
+      ..docs.add('/// Generated Mapper class used for packing and unpacking "google.protobuf.Any" fields or values');
+
+    final output = _allFileOutput(buildStep);
+    final emitter = DartEmitter.scoped(useNullSafetySyntax: true, orderDirectives: true);
+
+    final code = StringBuffer();
+    for (final lib in importedLibraries) {
+      code.write("import '$lib';");
+    }
+    code.write('${mapperBuilder.build().accept(emitter)}');
+
+    return buildStep.writeAsString(output, DartFormatter().format(code.toString()));
+  }
+
+  Future<List<ClassElement>> _getMapProtoClasses(BuildStep buildStep) async {
+    final mappedClasses = <ClassElement>[];
+    await for (final input in buildStep.findAssets(_allFilesInLib)) {
+      if (!await buildStep.resolver.isLibrary(input)) {
+        continue;
+      }
+      final library = await buildStep.resolver.libraryFor(input);
+      var libraryReader = sg.LibraryReader(library);
+      final classesInLibrary = libraryReader.annotatedWith(typeChecker);
+      for (final classInLib in classesInLibrary) {
+        if (classInLib.element is ClassElement) {
+          mappedClasses.add(classInLib.element as ClassElement);
+        }
+      }
+    }
+    return mappedClasses;
+  }
+
+  static AssetId _allFileOutput(BuildStep buildStep) {
+    return AssetId(
+      buildStep.inputId.package,
+      p.join('lib', 'src/dynamic_mapper.g.dart'),
+    );
+  }
+
+  @override
+  Map<String, List<String>> get buildExtensions {
+    return const {
+      r'$lib$': ['src/dynamic_mapper.g.dart']
+    };
+  }
+
+  Code? _toProto(Set<String> importedLibraries, List<ClassElement> mappedClasses) {
+    final code = StringBuffer();
+    // Base types - uses same prefixes as the other types
+    code.write('''
+    if (value is String) {
+      return Any(value: utf8.encode(value), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}String');
+    }
+    if (value is int) {
+      final byteSize = (value.bitLength / 8).ceil();
+      if (byteSize < 2) {
+        return Any(value: Uint8List(1)..buffer.asByteData().setInt8(0, value), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int8');
+      } else if (byteSize < 3) {
+        return Any(value: Uint8List(2)..buffer.asByteData().setInt16(0, value, Endian.big), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int16');
+      } else if (byteSize < 4) {
+        return Any(value: Uint8List(4)..buffer.asByteData().setInt32(0, value, Endian.big), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int32');
+      } else {
+        return Any(value: Uint8List(8)..buffer.asByteData().setInt64(0, value, Endian.big), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int64');
+      }
+    }
+    if (value is double) {
+      return Any(value: Uint8List(8)..buffer.asByteData().setFloat64(0, value, Endian.big), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}float64');
+    }
+    if (value == null) {
+      return Any(value: null, typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Null');
+    }
+    if (value is bool) {
+      return Any(value: value ? [1] : [0], typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Boolean');
+    }
+    if (value is Decimal) {
+      return Any(value: utf8.encode(value.toString()), typeUrl: '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Decimal');
+    }
+    ''');
+    // Registry types
+    for (final classElement in mappedClasses) {
+      final typeName = classElement.name;
+      final gTypeName = '$_generatedPrefix$typeName';
+      final gTypeUrl = '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}$gTypeName';
+      code.write('if (value is $typeName) {');
+      if (classElement.isEnum) {
+        code.write("return Any(value: Uint8List(max(1, (value.index.bitLength / 8).ceil()))..buffer.asByteData().setUint8(0, value.index), typeUrl: '$gTypeUrl');");
+      } else {
+         code.write('return Any.pack(\$${typeName}ProtoMapper().toProto(value), typeUrlPrefix: \'$_typeUrlPrefix\');');
+      }
+      code.write('}');
+
+      // Remember to import the actual classes
+      importedLibraries.add(classElement.library.identifier);
+    }
+
+    code.write('throw "\${value.runtimeType} not (yet) supported!";');
+    return Code(code.toString());
+  }
+
+  Code? _fromProto(Set<String> importedLibraries, List<ClassElement> mappedClasses) {
+    final code = StringBuffer('switch (proto.typeUrl) {\n');
+    // Base types
+    code.write('''
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}String':
+        return utf8.decode(proto.value);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int8':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int16':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getUint16(0, Endian.big);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int32':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getUint32(0, Endian.big);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}int64':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getUint64(0, Endian.big);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}float32':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getFloat32(0, Endian.big);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}float64':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getFloat64(0, Endian.big);
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Null':
+        return null;
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Boolean':
+        return proto.value[0] == 1;
+      case '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}Decimal':
+        return Decimal.parse(utf8.decode(proto.value));
+    ''');
+    // Registry types
+    for (final classElement in mappedClasses) {
+      final typeName = classElement.name;
+      final gTypeName = '$_generatedPrefix$typeName';
+      final gTypeUrl = '${_typeUrlPrefix.isNotEmpty ? '$_typeUrlPrefix/' : ''}$gTypeName';
+      final filename = classElement.library.identifier.substring(classElement.library.identifier.lastIndexOf('/') + 1).replaceAll('.dart', '');
+      code.write("case '$gTypeUrl':");
+      if (classElement.isEnum) {
+        code.write('final index = Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);');
+        code.write('return $typeName.values[index];');
+        // importedLibraries.add('$_generatedPbFolder/$filename.pbenum.dart');
+      } else {
+        code.write('return proto.unpackInto($gTypeName()).to$typeName();');
+        importedLibraries.add('$_generatedPbFolder/$filename.pb.dart');
+      }
+    }
+    code.writeln('default: throw "\${proto.typeUrl} not (yet) supported!"; }');
+    return Code(code.toString());
+  }
+}

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generator.dart
@@ -5,6 +5,7 @@ import 'field_code_generators/bool_field_code_generator.dart';
 import 'field_code_generators/datetime_field_code_generator.dart';
 import 'field_code_generators/decimal_field_code_generator.dart';
 import 'field_code_generators/duration_field_code_generator.dart';
+import 'field_code_generators/dynamic_field_code_generator.dart';
 import 'field_code_generators/entity_field_code_generator.dart';
 import 'field_code_generators/enum_field_code_generator.dart';
 import 'field_code_generators/generic_field_code_generator.dart';
@@ -152,6 +153,14 @@ abstract class FieldCodeGenerator {
     if (fieldDescriptor.fieldElementType.isDartCoreIterable &&
         fieldDescriptor.iterableParameterType != null) {
       return IterableFieldCodeGenerator(
+        fieldDescriptor,
+        refName: refName,
+        protoRefName: protoRefName,
+      );
+    }
+    if (fieldDescriptor.fieldElementType.isDynamic ||
+        fieldDescriptor.fieldElementType.isDartCoreObject) {
+      return DynamicFieldCodeGenerator(
         fieldDescriptor,
         refName: refName,
         protoRefName: protoRefName,

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/dynamic_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/dynamic_field_code_generator.dart
@@ -1,0 +1,22 @@
+import '../field_code_generator.dart';
+import '../field_descriptor.dart';
+
+class DynamicFieldCodeGenerator extends FieldCodeGenerator {
+  DynamicFieldCodeGenerator(
+    FieldDescriptor fieldDescriptor, {
+    String refName = FieldCodeGenerator.defaultRefName,
+    String protoRefName = FieldCodeGenerator.defaultProtoRefName,
+  }) : super(
+          fieldDescriptor,
+          refName: refName,
+          protoRefName: protoRefName,
+        );
+
+  @override
+  String get toProtoExpression =>
+      ''' DynamicProtoMapper.toProto($instanceReference)''';
+
+  @override
+  String get fromProtoNonNullableExpression =>
+      ''' DynamicProtoMapper.fromProto($ref$fieldName)''';
+}

--- a/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
+++ b/proto_mapper/proto_generator/lib/src/proto_mapper/field_code_generators/map_field_code_generator.dart
@@ -80,6 +80,5 @@ class MapFieldCodeGenerator extends FieldCodeGenerator {
 
   @override
   String get fromProtoNonNullableExpression =>
-      // '''List<${fieldDescriptor.parameterTypeName}>.unmodifiable($ref$protoFieldName.map((e) => $_protoToValue))''';
       '''$ref$protoFieldName.map((k, v) => $_protoToValue)''';
 }

--- a/proto_mapper/proto_generator/pubspec.yaml
+++ b/proto_mapper/proto_generator/pubspec.yaml
@@ -2,7 +2,7 @@ name: proto_generator
 description: Code generation of .proto and Dart mapper classes to facilitate the usage of PODOs (plain-old-dart-objects) with gRPC
 homepage: https://github.com/squarealfa/dart_framework/tree/main/proto_mapper/proto_generator
 repository: https://github.com/squarealfa/dart_framework
-version: 3.0.2
+version: 3.0.3
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -10,6 +10,7 @@ environment:
 dependencies:
   source_gen: ^1.2.1
   proto_annotations: ^2.0.4
+  dart_style: ^2.0.0
   decimal: ^2.0.0
   grpc: ^3.0.2
   analyzer: ^3.0.0
@@ -21,6 +22,7 @@ dependencies:
 dev_dependencies:
   lints: ^1.0.1
   test: ^1.17.0
+  code_builder: ^4.1.0
 
 # dependency_overrides:
 #   proto_annotations:

--- a/proto_mapper/test/build.yaml
+++ b/proto_mapper/test/build.yaml
@@ -9,3 +9,13 @@ targets:
         options:
           dateTimePrecision: microseconds
           durationPrecision: microseconds
+      proto_generator:proto_dynamic_mapper_generator:
+        options:
+          # Defaults to "enabled: false, dynamic mapper needs to be turned on explicitly
+          enabled: true
+          # Defaults to "type.googleapis.com"
+          typeUrlPrefix: type.protogenerator.test
+          # Defaults to "G", should match the "prefix" option on "proto_mapper_generator"
+          generatedPrefix: G
+          # Defaults to "../grpc", should match the output folder used by the "protoc" command
+          generatedProtobufFolder: ../grpc

--- a/proto_mapper/test/gen.sh
+++ b/proto_mapper/test/gen.sh
@@ -16,5 +16,6 @@ mkdir ./lib/grpc
 
 
 # generate dart grpc business model files
-protoc --dart_out=grpc:lib/grpc/ -Iproto/ ./proto/*.proto
+protoc --dart_out=grpc:lib/grpc -I%PROTOC_HOME%/include %PROTOC_HOME%/include/google/protobuf/any.proto
+protoc --dart_out=grpc:lib/grpc -Iproto/ -I%PROTOC_HOME%/include ./proto/*.proto
 dart format fix lib/grpc/

--- a/proto_mapper/test/lib/grpc/any_host.pb.dart
+++ b/proto_mapper/test/lib/grpc/any_host.pb.dart
@@ -1,0 +1,539 @@
+///
+//  Generated code. Do not modify.
+//  source: any_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'google/protobuf/any.pb.dart' as $5;
+
+class GDynamicObject extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GDynamicObject',
+      createEmptyInstance: create)
+    ..aOM<$5.Any>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'dynamicProperty',
+        subBuilder: $5.Any.create)
+    ..aOM<$5.Any>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'objectProperty',
+        subBuilder: $5.Any.create)
+    ..hasRequiredFields = false;
+
+  GDynamicObject._() : super();
+  factory GDynamicObject({
+    $5.Any? dynamicProperty,
+    $5.Any? objectProperty,
+  }) {
+    final _result = create();
+    if (dynamicProperty != null) {
+      _result.dynamicProperty = dynamicProperty;
+    }
+    if (objectProperty != null) {
+      _result.objectProperty = objectProperty;
+    }
+    return _result;
+  }
+  factory GDynamicObject.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GDynamicObject.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GDynamicObject clone() => GDynamicObject()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GDynamicObject copyWith(void Function(GDynamicObject) updates) =>
+      super.copyWith((message) => updates(message as GDynamicObject))
+          as GDynamicObject; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GDynamicObject create() => GDynamicObject._();
+  GDynamicObject createEmptyInstance() => create();
+  static $pb.PbList<GDynamicObject> createRepeated() =>
+      $pb.PbList<GDynamicObject>();
+  @$core.pragma('dart2js:noInline')
+  static GDynamicObject getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GDynamicObject>(create);
+  static GDynamicObject? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $5.Any get dynamicProperty => $_getN(0);
+  @$pb.TagNumber(1)
+  set dynamicProperty($5.Any v) {
+    setField(1, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasDynamicProperty() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearDynamicProperty() => clearField(1);
+  @$pb.TagNumber(1)
+  $5.Any ensureDynamicProperty() => $_ensure(0);
+
+  @$pb.TagNumber(2)
+  $5.Any get objectProperty => $_getN(1);
+  @$pb.TagNumber(2)
+  set objectProperty($5.Any v) {
+    setField(2, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasObjectProperty() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearObjectProperty() => clearField(2);
+  @$pb.TagNumber(2)
+  $5.Any ensureObjectProperty() => $_ensure(1);
+}
+
+class GListOfDynamicObject extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfDynamicObject',
+      createEmptyInstance: create)
+    ..pc<GDynamicObject>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GDynamicObject.create)
+    ..hasRequiredFields = false;
+
+  GListOfDynamicObject._() : super();
+  factory GListOfDynamicObject({
+    $core.Iterable<GDynamicObject>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfDynamicObject.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfDynamicObject.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicObject clone() =>
+      GListOfDynamicObject()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicObject copyWith(void Function(GListOfDynamicObject) updates) =>
+      super.copyWith((message) => updates(message as GListOfDynamicObject))
+          as GListOfDynamicObject; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicObject create() => GListOfDynamicObject._();
+  GListOfDynamicObject createEmptyInstance() => create();
+  static $pb.PbList<GListOfDynamicObject> createRepeated() =>
+      $pb.PbList<GListOfDynamicObject>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicObject getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfDynamicObject>(create);
+  static GListOfDynamicObject? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GDynamicObject> get items => $_getList(0);
+}
+
+class GDynamicMap extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GDynamicMap',
+      createEmptyInstance: create)
+    ..m<$core.String, $5.Any>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'dynamicMap',
+        entryClassName: 'GDynamicMap.DynamicMapEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: $5.Any.create)
+    ..m<$core.String, $5.Any>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'objectMap',
+        entryClassName: 'GDynamicMap.ObjectMapEntry',
+        keyFieldType: $pb.PbFieldType.OS,
+        valueFieldType: $pb.PbFieldType.OM,
+        valueCreator: $5.Any.create)
+    ..hasRequiredFields = false;
+
+  GDynamicMap._() : super();
+  factory GDynamicMap({
+    $core.Map<$core.String, $5.Any>? dynamicMap,
+    $core.Map<$core.String, $5.Any>? objectMap,
+  }) {
+    final _result = create();
+    if (dynamicMap != null) {
+      _result.dynamicMap.addAll(dynamicMap);
+    }
+    if (objectMap != null) {
+      _result.objectMap.addAll(objectMap);
+    }
+    return _result;
+  }
+  factory GDynamicMap.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GDynamicMap.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GDynamicMap clone() => GDynamicMap()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GDynamicMap copyWith(void Function(GDynamicMap) updates) =>
+      super.copyWith((message) => updates(message as GDynamicMap))
+          as GDynamicMap; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GDynamicMap create() => GDynamicMap._();
+  GDynamicMap createEmptyInstance() => create();
+  static $pb.PbList<GDynamicMap> createRepeated() => $pb.PbList<GDynamicMap>();
+  @$core.pragma('dart2js:noInline')
+  static GDynamicMap getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GDynamicMap>(create);
+  static GDynamicMap? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.Map<$core.String, $5.Any> get dynamicMap => $_getMap(0);
+
+  @$pb.TagNumber(2)
+  $core.Map<$core.String, $5.Any> get objectMap => $_getMap(1);
+}
+
+class GListOfDynamicMap extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfDynamicMap',
+      createEmptyInstance: create)
+    ..pc<GDynamicMap>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GDynamicMap.create)
+    ..hasRequiredFields = false;
+
+  GListOfDynamicMap._() : super();
+  factory GListOfDynamicMap({
+    $core.Iterable<GDynamicMap>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfDynamicMap.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfDynamicMap.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicMap clone() => GListOfDynamicMap()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicMap copyWith(void Function(GListOfDynamicMap) updates) =>
+      super.copyWith((message) => updates(message as GListOfDynamicMap))
+          as GListOfDynamicMap; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicMap create() => GListOfDynamicMap._();
+  GListOfDynamicMap createEmptyInstance() => create();
+  static $pb.PbList<GListOfDynamicMap> createRepeated() =>
+      $pb.PbList<GListOfDynamicMap>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicMap getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfDynamicMap>(create);
+  static GListOfDynamicMap? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GDynamicMap> get items => $_getList(0);
+}
+
+class GDynamicSet extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GDynamicSet',
+      createEmptyInstance: create)
+    ..pc<$5.Any>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'dynamicSet',
+        $pb.PbFieldType.PM,
+        subBuilder: $5.Any.create)
+    ..pc<$5.Any>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'objectSet',
+        $pb.PbFieldType.PM,
+        subBuilder: $5.Any.create)
+    ..hasRequiredFields = false;
+
+  GDynamicSet._() : super();
+  factory GDynamicSet({
+    $core.Iterable<$5.Any>? dynamicSet,
+    $core.Iterable<$5.Any>? objectSet,
+  }) {
+    final _result = create();
+    if (dynamicSet != null) {
+      _result.dynamicSet.addAll(dynamicSet);
+    }
+    if (objectSet != null) {
+      _result.objectSet.addAll(objectSet);
+    }
+    return _result;
+  }
+  factory GDynamicSet.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GDynamicSet.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GDynamicSet clone() => GDynamicSet()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GDynamicSet copyWith(void Function(GDynamicSet) updates) =>
+      super.copyWith((message) => updates(message as GDynamicSet))
+          as GDynamicSet; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GDynamicSet create() => GDynamicSet._();
+  GDynamicSet createEmptyInstance() => create();
+  static $pb.PbList<GDynamicSet> createRepeated() => $pb.PbList<GDynamicSet>();
+  @$core.pragma('dart2js:noInline')
+  static GDynamicSet getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GDynamicSet>(create);
+  static GDynamicSet? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$5.Any> get dynamicSet => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$5.Any> get objectSet => $_getList(1);
+}
+
+class GListOfDynamicSet extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfDynamicSet',
+      createEmptyInstance: create)
+    ..pc<GDynamicSet>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GDynamicSet.create)
+    ..hasRequiredFields = false;
+
+  GListOfDynamicSet._() : super();
+  factory GListOfDynamicSet({
+    $core.Iterable<GDynamicSet>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfDynamicSet.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfDynamicSet.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicSet clone() => GListOfDynamicSet()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicSet copyWith(void Function(GListOfDynamicSet) updates) =>
+      super.copyWith((message) => updates(message as GListOfDynamicSet))
+          as GListOfDynamicSet; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicSet create() => GListOfDynamicSet._();
+  GListOfDynamicSet createEmptyInstance() => create();
+  static $pb.PbList<GListOfDynamicSet> createRepeated() =>
+      $pb.PbList<GListOfDynamicSet>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicSet getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfDynamicSet>(create);
+  static GListOfDynamicSet? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GDynamicSet> get items => $_getList(0);
+}
+
+class GDynamicList extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GDynamicList',
+      createEmptyInstance: create)
+    ..pc<$5.Any>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'dynamicList',
+        $pb.PbFieldType.PM,
+        subBuilder: $5.Any.create)
+    ..pc<$5.Any>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'objectList',
+        $pb.PbFieldType.PM,
+        subBuilder: $5.Any.create)
+    ..hasRequiredFields = false;
+
+  GDynamicList._() : super();
+  factory GDynamicList({
+    $core.Iterable<$5.Any>? dynamicList,
+    $core.Iterable<$5.Any>? objectList,
+  }) {
+    final _result = create();
+    if (dynamicList != null) {
+      _result.dynamicList.addAll(dynamicList);
+    }
+    if (objectList != null) {
+      _result.objectList.addAll(objectList);
+    }
+    return _result;
+  }
+  factory GDynamicList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GDynamicList.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GDynamicList clone() => GDynamicList()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GDynamicList copyWith(void Function(GDynamicList) updates) =>
+      super.copyWith((message) => updates(message as GDynamicList))
+          as GDynamicList; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GDynamicList create() => GDynamicList._();
+  GDynamicList createEmptyInstance() => create();
+  static $pb.PbList<GDynamicList> createRepeated() =>
+      $pb.PbList<GDynamicList>();
+  @$core.pragma('dart2js:noInline')
+  static GDynamicList getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GDynamicList>(create);
+  static GDynamicList? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<$5.Any> get dynamicList => $_getList(0);
+
+  @$pb.TagNumber(2)
+  $core.List<$5.Any> get objectList => $_getList(1);
+}
+
+class GListOfDynamicList extends $pb.GeneratedMessage {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'GListOfDynamicList',
+      createEmptyInstance: create)
+    ..pc<GDynamicList>(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'items',
+        $pb.PbFieldType.PM,
+        subBuilder: GDynamicList.create)
+    ..hasRequiredFields = false;
+
+  GListOfDynamicList._() : super();
+  factory GListOfDynamicList({
+    $core.Iterable<GDynamicList>? items,
+  }) {
+    final _result = create();
+    if (items != null) {
+      _result.items.addAll(items);
+    }
+    return _result;
+  }
+  factory GListOfDynamicList.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory GListOfDynamicList.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicList clone() => GListOfDynamicList()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  GListOfDynamicList copyWith(void Function(GListOfDynamicList) updates) =>
+      super.copyWith((message) => updates(message as GListOfDynamicList))
+          as GListOfDynamicList; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicList create() => GListOfDynamicList._();
+  GListOfDynamicList createEmptyInstance() => create();
+  static $pb.PbList<GListOfDynamicList> createRepeated() =>
+      $pb.PbList<GListOfDynamicList>();
+  @$core.pragma('dart2js:noInline')
+  static GListOfDynamicList getDefault() => _defaultInstance ??=
+      $pb.GeneratedMessage.$_defaultFor<GListOfDynamicList>(create);
+  static GListOfDynamicList? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.List<GDynamicList> get items => $_getList(0);
+}

--- a/proto_mapper/test/lib/grpc/any_host.pbenum.dart
+++ b/proto_mapper/test/lib/grpc/any_host.pbenum.dart
@@ -1,0 +1,6 @@
+///
+//  Generated code. Do not modify.
+//  source: any_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/proto_mapper/test/lib/grpc/any_host.pbjson.dart
+++ b/proto_mapper/test/lib/grpc/any_host.pbjson.dart
@@ -1,0 +1,208 @@
+///
+//  Generated code. Do not modify.
+//  source: any_host.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use gDynamicObjectDescriptor instead')
+const GDynamicObject$json = {
+  '1': 'GDynamicObject',
+  '2': [
+    {
+      '1': 'dynamic_property',
+      '3': 1,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'dynamicProperty'
+    },
+    {
+      '1': 'object_property',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'objectProperty'
+    },
+  ],
+};
+
+/// Descriptor for `GDynamicObject`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gDynamicObjectDescriptor = $convert.base64Decode(
+    'Cg5HRHluYW1pY09iamVjdBI/ChBkeW5hbWljX3Byb3BlcnR5GAEgASgLMhQuZ29vZ2xlLnByb3RvYnVmLkFueVIPZHluYW1pY1Byb3BlcnR5Ej0KD29iamVjdF9wcm9wZXJ0eRgCIAEoCzIULmdvb2dsZS5wcm90b2J1Zi5BbnlSDm9iamVjdFByb3BlcnR5');
+@$core.Deprecated('Use gListOfDynamicObjectDescriptor instead')
+const GListOfDynamicObject$json = {
+  '1': 'GListOfDynamicObject',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GDynamicObject',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfDynamicObject`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfDynamicObjectDescriptor = $convert.base64Decode(
+    'ChRHTGlzdE9mRHluYW1pY09iamVjdBIlCgVpdGVtcxgBIAMoCzIPLkdEeW5hbWljT2JqZWN0UgVpdGVtcw==');
+@$core.Deprecated('Use gDynamicMapDescriptor instead')
+const GDynamicMap$json = {
+  '1': 'GDynamicMap',
+  '2': [
+    {
+      '1': 'dynamic_map',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GDynamicMap.DynamicMapEntry',
+      '10': 'dynamicMap'
+    },
+    {
+      '1': 'object_map',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.GDynamicMap.ObjectMapEntry',
+      '10': 'objectMap'
+    },
+  ],
+  '3': [GDynamicMap_DynamicMapEntry$json, GDynamicMap_ObjectMapEntry$json],
+};
+
+@$core.Deprecated('Use gDynamicMapDescriptor instead')
+const GDynamicMap_DynamicMapEntry$json = {
+  '1': 'DynamicMapEntry',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'value'
+    },
+  ],
+  '7': {'7': true},
+};
+
+@$core.Deprecated('Use gDynamicMapDescriptor instead')
+const GDynamicMap_ObjectMapEntry$json = {
+  '1': 'ObjectMapEntry',
+  '2': [
+    {'1': 'key', '3': 1, '4': 1, '5': 9, '10': 'key'},
+    {
+      '1': 'value',
+      '3': 2,
+      '4': 1,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'value'
+    },
+  ],
+  '7': {'7': true},
+};
+
+/// Descriptor for `GDynamicMap`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gDynamicMapDescriptor = $convert.base64Decode(
+    'CgtHRHluYW1pY01hcBI9CgtkeW5hbWljX21hcBgBIAMoCzIcLkdEeW5hbWljTWFwLkR5bmFtaWNNYXBFbnRyeVIKZHluYW1pY01hcBI6CgpvYmplY3RfbWFwGAIgAygLMhsuR0R5bmFtaWNNYXAuT2JqZWN0TWFwRW50cnlSCW9iamVjdE1hcBpTCg9EeW5hbWljTWFwRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSKgoFdmFsdWUYAiABKAsyFC5nb29nbGUucHJvdG9idWYuQW55UgV2YWx1ZToCOAEaUgoOT2JqZWN0TWFwRW50cnkSEAoDa2V5GAEgASgJUgNrZXkSKgoFdmFsdWUYAiABKAsyFC5nb29nbGUucHJvdG9idWYuQW55UgV2YWx1ZToCOAE=');
+@$core.Deprecated('Use gListOfDynamicMapDescriptor instead')
+const GListOfDynamicMap$json = {
+  '1': 'GListOfDynamicMap',
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GDynamicMap', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfDynamicMap`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfDynamicMapDescriptor = $convert.base64Decode(
+    'ChFHTGlzdE9mRHluYW1pY01hcBIiCgVpdGVtcxgBIAMoCzIMLkdEeW5hbWljTWFwUgVpdGVtcw==');
+@$core.Deprecated('Use gDynamicSetDescriptor instead')
+const GDynamicSet$json = {
+  '1': 'GDynamicSet',
+  '2': [
+    {
+      '1': 'dynamic_set',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'dynamicSet'
+    },
+    {
+      '1': 'object_set',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'objectSet'
+    },
+  ],
+};
+
+/// Descriptor for `GDynamicSet`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gDynamicSetDescriptor = $convert.base64Decode(
+    'CgtHRHluYW1pY1NldBI1CgtkeW5hbWljX3NldBgBIAMoCzIULmdvb2dsZS5wcm90b2J1Zi5BbnlSCmR5bmFtaWNTZXQSMwoKb2JqZWN0X3NldBgCIAMoCzIULmdvb2dsZS5wcm90b2J1Zi5BbnlSCW9iamVjdFNldA==');
+@$core.Deprecated('Use gListOfDynamicSetDescriptor instead')
+const GListOfDynamicSet$json = {
+  '1': 'GListOfDynamicSet',
+  '2': [
+    {'1': 'items', '3': 1, '4': 3, '5': 11, '6': '.GDynamicSet', '10': 'items'},
+  ],
+};
+
+/// Descriptor for `GListOfDynamicSet`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfDynamicSetDescriptor = $convert.base64Decode(
+    'ChFHTGlzdE9mRHluYW1pY1NldBIiCgVpdGVtcxgBIAMoCzIMLkdEeW5hbWljU2V0UgVpdGVtcw==');
+@$core.Deprecated('Use gDynamicListDescriptor instead')
+const GDynamicList$json = {
+  '1': 'GDynamicList',
+  '2': [
+    {
+      '1': 'dynamic_list',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'dynamicList'
+    },
+    {
+      '1': 'object_list',
+      '3': 2,
+      '4': 3,
+      '5': 11,
+      '6': '.google.protobuf.Any',
+      '10': 'objectList'
+    },
+  ],
+};
+
+/// Descriptor for `GDynamicList`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gDynamicListDescriptor = $convert.base64Decode(
+    'CgxHRHluYW1pY0xpc3QSNwoMZHluYW1pY19saXN0GAEgAygLMhQuZ29vZ2xlLnByb3RvYnVmLkFueVILZHluYW1pY0xpc3QSNQoLb2JqZWN0X2xpc3QYAiADKAsyFC5nb29nbGUucHJvdG9idWYuQW55UgpvYmplY3RMaXN0');
+@$core.Deprecated('Use gListOfDynamicListDescriptor instead')
+const GListOfDynamicList$json = {
+  '1': 'GListOfDynamicList',
+  '2': [
+    {
+      '1': 'items',
+      '3': 1,
+      '4': 3,
+      '5': 11,
+      '6': '.GDynamicList',
+      '10': 'items'
+    },
+  ],
+};
+
+/// Descriptor for `GListOfDynamicList`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List gListOfDynamicListDescriptor = $convert.base64Decode(
+    'ChJHTGlzdE9mRHluYW1pY0xpc3QSIwoFaXRlbXMYASADKAsyDS5HRHluYW1pY0xpc3RSBWl0ZW1z');

--- a/proto_mapper/test/lib/grpc/google/protobuf/any.pb.dart
+++ b/proto_mapper/test/lib/grpc/google/protobuf/any.pb.dart
@@ -1,0 +1,113 @@
+///
+//  Generated code. Do not modify.
+//  source: google/protobuf/any.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields
+
+import 'dart:core' as $core;
+
+import 'package:protobuf/protobuf.dart' as $pb;
+
+import 'package:protobuf/src/protobuf/mixins/well_known.dart' as $mixin;
+
+class Any extends $pb.GeneratedMessage with $mixin.AnyMixin {
+  static final $pb.BuilderInfo _i = $pb.BuilderInfo(
+      const $core.bool.fromEnvironment('protobuf.omit_message_names')
+          ? ''
+          : 'Any',
+      package: const $pb.PackageName(
+          $core.bool.fromEnvironment('protobuf.omit_message_names')
+              ? ''
+              : 'google.protobuf'),
+      createEmptyInstance: create,
+      toProto3Json: $mixin.AnyMixin.toProto3JsonHelper,
+      fromProto3Json: $mixin.AnyMixin.fromProto3JsonHelper)
+    ..aOS(
+        1,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'typeUrl')
+    ..a<$core.List<$core.int>>(
+        2,
+        const $core.bool.fromEnvironment('protobuf.omit_field_names')
+            ? ''
+            : 'value',
+        $pb.PbFieldType.OY)
+    ..hasRequiredFields = false;
+
+  Any._() : super();
+  factory Any({
+    $core.String? typeUrl,
+    $core.List<$core.int>? value,
+  }) {
+    final _result = create();
+    if (typeUrl != null) {
+      _result.typeUrl = typeUrl;
+    }
+    if (value != null) {
+      _result.value = value;
+    }
+    return _result;
+  }
+  factory Any.fromBuffer($core.List<$core.int> i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromBuffer(i, r);
+  factory Any.fromJson($core.String i,
+          [$pb.ExtensionRegistry r = $pb.ExtensionRegistry.EMPTY]) =>
+      create()..mergeFromJson(i, r);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.deepCopy] instead. '
+      'Will be removed in next major version')
+  Any clone() => Any()..mergeFromMessage(this);
+  @$core.Deprecated('Using this can add significant overhead to your binary. '
+      'Use [GeneratedMessageGenericExtensions.rebuild] instead. '
+      'Will be removed in next major version')
+  Any copyWith(void Function(Any) updates) =>
+      super.copyWith((message) => updates(message as Any))
+          as Any; // ignore: deprecated_member_use
+  $pb.BuilderInfo get info_ => _i;
+  @$core.pragma('dart2js:noInline')
+  static Any create() => Any._();
+  Any createEmptyInstance() => create();
+  static $pb.PbList<Any> createRepeated() => $pb.PbList<Any>();
+  @$core.pragma('dart2js:noInline')
+  static Any getDefault() =>
+      _defaultInstance ??= $pb.GeneratedMessage.$_defaultFor<Any>(create);
+  static Any? _defaultInstance;
+
+  @$pb.TagNumber(1)
+  $core.String get typeUrl => $_getSZ(0);
+  @$pb.TagNumber(1)
+  set typeUrl($core.String v) {
+    $_setString(0, v);
+  }
+
+  @$pb.TagNumber(1)
+  $core.bool hasTypeUrl() => $_has(0);
+  @$pb.TagNumber(1)
+  void clearTypeUrl() => clearField(1);
+
+  @$pb.TagNumber(2)
+  $core.List<$core.int> get value => $_getN(1);
+  @$pb.TagNumber(2)
+  set value($core.List<$core.int> v) {
+    $_setBytes(1, v);
+  }
+
+  @$pb.TagNumber(2)
+  $core.bool hasValue() => $_has(1);
+  @$pb.TagNumber(2)
+  void clearValue() => clearField(2);
+
+  /// Creates a new [Any] encoding [message].
+  ///
+  /// The [typeUrl] will be [typeUrlPrefix]/`fullName` where `fullName` is
+  /// the fully qualified name of the type of [message].
+  static Any pack($pb.GeneratedMessage message,
+      {$core.String typeUrlPrefix = 'type.googleapis.com'}) {
+    final result = create();
+    $mixin.AnyMixin.packIntoAny(result, message, typeUrlPrefix: typeUrlPrefix);
+    return result;
+  }
+}

--- a/proto_mapper/test/lib/grpc/google/protobuf/any.pbenum.dart
+++ b/proto_mapper/test/lib/grpc/google/protobuf/any.pbenum.dart
@@ -1,0 +1,6 @@
+///
+//  Generated code. Do not modify.
+//  source: google/protobuf/any.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields

--- a/proto_mapper/test/lib/grpc/google/protobuf/any.pbjson.dart
+++ b/proto_mapper/test/lib/grpc/google/protobuf/any.pbjson.dart
@@ -1,0 +1,23 @@
+///
+//  Generated code. Do not modify.
+//  source: google/protobuf/any.proto
+//
+// @dart = 2.12
+// ignore_for_file: annotate_overrides,camel_case_types,unnecessary_const,non_constant_identifier_names,library_prefixes,unused_import,unused_shown_name,return_of_invalid_type,unnecessary_this,prefer_final_fields,deprecated_member_use_from_same_package
+
+import 'dart:core' as $core;
+import 'dart:convert' as $convert;
+import 'dart:typed_data' as $typed_data;
+
+@$core.Deprecated('Use anyDescriptor instead')
+const Any$json = {
+  '1': 'Any',
+  '2': [
+    {'1': 'type_url', '3': 1, '4': 1, '5': 9, '10': 'typeUrl'},
+    {'1': 'value', '3': 2, '4': 1, '5': 12, '10': 'value'},
+  ],
+};
+
+/// Descriptor for `Any`. Decode as a `google.protobuf.DescriptorProto`.
+final $typed_data.Uint8List anyDescriptor = $convert.base64Decode(
+    'CgNBbnkSGQoIdHlwZV91cmwYASABKAlSB3R5cGVVcmwSFAoFdmFsdWUYAiABKAxSBXZhbHVl');

--- a/proto_mapper/test/lib/proto_generator_test.dart
+++ b/proto_mapper/test/lib/proto_generator_test.dart
@@ -1,3 +1,7 @@
 export 'src/category.dart';
 export 'src/ingredient.dart';
 export 'src/recipe.dart';
+export 'src/utensils.dart';
+export 'src/any_host.dart';
+// Required to unpack "dynamic" objects in dependent modules, can be done based on typeUrl string
+export 'src/dynamic_mapper.g.dart';

--- a/proto_mapper/test/lib/src/any_host.dart
+++ b/proto_mapper/test/lib/src/any_host.dart
@@ -1,0 +1,34 @@
+import 'package:proto_annotations/proto_annotations.dart';
+import 'package:proto_generator_test/grpc/any_host.pb.dart';
+import 'package:proto_generator_test/src/dynamic_mapper.g.dart';
+
+part 'any_host.g.dart';
+
+@proto
+@mapProto
+class DynamicObject {
+  late dynamic dynamicProperty;
+  late Object objectProperty;
+}
+
+@proto
+@mapProto
+class DynamicMap {
+  late Map<String, dynamic> dynamicMap;
+  late Map<String, Object> objectMap;
+}
+
+@proto
+@mapProto
+class DynamicSet {
+  late Set<dynamic> dynamicSet;
+  late Set<Object> objectSet;
+}
+
+@proto
+@mapProto
+class DynamicList {
+  late List<dynamic> dynamicList;
+  late List<Object> objectList;
+}
+

--- a/proto_mapper/test/lib/src/any_host.g.dart
+++ b/proto_mapper/test/lib/src/any_host.g.dart
@@ -1,0 +1,221 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'any_host.dart';
+
+// **************************************************************************
+// ProtoMapperGenerator
+// **************************************************************************
+
+class $DynamicObjectProtoMapper
+    implements ProtoMapper<DynamicObject, GDynamicObject> {
+  const $DynamicObjectProtoMapper();
+
+  @override
+  DynamicObject fromProto(GDynamicObject proto) =>
+      _$DynamicObjectFromProto(proto);
+
+  @override
+  GDynamicObject toProto(DynamicObject entity) =>
+      _$DynamicObjectToProto(entity);
+
+  DynamicObject fromJson(String json) =>
+      _$DynamicObjectFromProto(GDynamicObject.fromJson(json));
+  String toJson(DynamicObject entity) =>
+      _$DynamicObjectToProto(entity).writeToJson();
+
+  String toBase64Proto(DynamicObject entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  DynamicObject fromBase64Proto(String base64Proto) =>
+      GDynamicObject.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toDynamicObject();
+}
+
+GDynamicObject _$DynamicObjectToProto(DynamicObject instance) {
+  var proto = GDynamicObject();
+
+  proto.dynamicProperty = DynamicProtoMapper.toProto(instance.dynamicProperty);
+  proto.objectProperty = DynamicProtoMapper.toProto(instance.objectProperty);
+
+  return proto;
+}
+
+DynamicObject _$DynamicObjectFromProto(GDynamicObject instance) =>
+    DynamicObject()
+      ..dynamicProperty = DynamicProtoMapper.fromProto(instance.dynamicProperty)
+      ..objectProperty = DynamicProtoMapper.fromProto(instance.objectProperty);
+
+extension $DynamicObjectProtoExtension on DynamicObject {
+  GDynamicObject toProto() => _$DynamicObjectToProto(this);
+  String toJson() => _$DynamicObjectToProto(this).writeToJson();
+
+  static DynamicObject fromProto(GDynamicObject proto) =>
+      _$DynamicObjectFromProto(proto);
+  static DynamicObject fromJson(String json) =>
+      _$DynamicObjectFromProto(GDynamicObject.fromJson(json));
+}
+
+extension $GDynamicObjectProtoExtension on GDynamicObject {
+  DynamicObject toDynamicObject() => _$DynamicObjectFromProto(this);
+}
+
+class $DynamicMapProtoMapper implements ProtoMapper<DynamicMap, GDynamicMap> {
+  const $DynamicMapProtoMapper();
+
+  @override
+  DynamicMap fromProto(GDynamicMap proto) => _$DynamicMapFromProto(proto);
+
+  @override
+  GDynamicMap toProto(DynamicMap entity) => _$DynamicMapToProto(entity);
+
+  DynamicMap fromJson(String json) =>
+      _$DynamicMapFromProto(GDynamicMap.fromJson(json));
+  String toJson(DynamicMap entity) => _$DynamicMapToProto(entity).writeToJson();
+
+  String toBase64Proto(DynamicMap entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  DynamicMap fromBase64Proto(String base64Proto) =>
+      GDynamicMap.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toDynamicMap();
+}
+
+GDynamicMap _$DynamicMapToProto(DynamicMap instance) {
+  var proto = GDynamicMap();
+
+  proto.dynamicMap.addAll(instance.dynamicMap
+      .map((k, v) => MapEntry(k, DynamicProtoMapper.toProto(v))));
+
+  proto.objectMap.addAll(instance.objectMap
+      .map((k, v) => MapEntry(k, DynamicProtoMapper.toProto(v))));
+
+  return proto;
+}
+
+DynamicMap _$DynamicMapFromProto(GDynamicMap instance) => DynamicMap()
+  ..dynamicMap = instance.dynamicMap
+      .map((k, v) => MapEntry(k, DynamicProtoMapper.fromProto(v)))
+  ..objectMap = instance.objectMap
+      .map((k, v) => MapEntry(k, DynamicProtoMapper.fromProto(v)));
+
+extension $DynamicMapProtoExtension on DynamicMap {
+  GDynamicMap toProto() => _$DynamicMapToProto(this);
+  String toJson() => _$DynamicMapToProto(this).writeToJson();
+
+  static DynamicMap fromProto(GDynamicMap proto) =>
+      _$DynamicMapFromProto(proto);
+  static DynamicMap fromJson(String json) =>
+      _$DynamicMapFromProto(GDynamicMap.fromJson(json));
+}
+
+extension $GDynamicMapProtoExtension on GDynamicMap {
+  DynamicMap toDynamicMap() => _$DynamicMapFromProto(this);
+}
+
+class $DynamicSetProtoMapper implements ProtoMapper<DynamicSet, GDynamicSet> {
+  const $DynamicSetProtoMapper();
+
+  @override
+  DynamicSet fromProto(GDynamicSet proto) => _$DynamicSetFromProto(proto);
+
+  @override
+  GDynamicSet toProto(DynamicSet entity) => _$DynamicSetToProto(entity);
+
+  DynamicSet fromJson(String json) =>
+      _$DynamicSetFromProto(GDynamicSet.fromJson(json));
+  String toJson(DynamicSet entity) => _$DynamicSetToProto(entity).writeToJson();
+
+  String toBase64Proto(DynamicSet entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  DynamicSet fromBase64Proto(String base64Proto) =>
+      GDynamicSet.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toDynamicSet();
+}
+
+GDynamicSet _$DynamicSetToProto(DynamicSet instance) {
+  var proto = GDynamicSet();
+
+  proto.dynamicSet
+      .addAll(instance.dynamicSet.map((e) => DynamicProtoMapper.toProto(e)));
+
+  proto.objectSet
+      .addAll(instance.objectSet.map((e) => DynamicProtoMapper.toProto(e)));
+
+  return proto;
+}
+
+DynamicSet _$DynamicSetFromProto(GDynamicSet instance) => DynamicSet()
+  ..dynamicSet = Set<dynamic>.unmodifiable(
+      instance.dynamicSet.map((e) => DynamicProtoMapper.fromProto(e)))
+  ..objectSet = Set<Object>.unmodifiable(
+      instance.objectSet.map((e) => DynamicProtoMapper.fromProto(e)));
+
+extension $DynamicSetProtoExtension on DynamicSet {
+  GDynamicSet toProto() => _$DynamicSetToProto(this);
+  String toJson() => _$DynamicSetToProto(this).writeToJson();
+
+  static DynamicSet fromProto(GDynamicSet proto) =>
+      _$DynamicSetFromProto(proto);
+  static DynamicSet fromJson(String json) =>
+      _$DynamicSetFromProto(GDynamicSet.fromJson(json));
+}
+
+extension $GDynamicSetProtoExtension on GDynamicSet {
+  DynamicSet toDynamicSet() => _$DynamicSetFromProto(this);
+}
+
+class $DynamicListProtoMapper
+    implements ProtoMapper<DynamicList, GDynamicList> {
+  const $DynamicListProtoMapper();
+
+  @override
+  DynamicList fromProto(GDynamicList proto) => _$DynamicListFromProto(proto);
+
+  @override
+  GDynamicList toProto(DynamicList entity) => _$DynamicListToProto(entity);
+
+  DynamicList fromJson(String json) =>
+      _$DynamicListFromProto(GDynamicList.fromJson(json));
+  String toJson(DynamicList entity) =>
+      _$DynamicListToProto(entity).writeToJson();
+
+  String toBase64Proto(DynamicList entity) =>
+      base64Encode(utf8.encode(entity.toProto().writeToJson()));
+
+  DynamicList fromBase64Proto(String base64Proto) =>
+      GDynamicList.fromJson(utf8.decode(base64Decode(base64Proto)))
+          .toDynamicList();
+}
+
+GDynamicList _$DynamicListToProto(DynamicList instance) {
+  var proto = GDynamicList();
+
+  proto.dynamicList
+      .addAll(instance.dynamicList.map((e) => DynamicProtoMapper.toProto(e)));
+
+  proto.objectList
+      .addAll(instance.objectList.map((e) => DynamicProtoMapper.toProto(e)));
+
+  return proto;
+}
+
+DynamicList _$DynamicListFromProto(GDynamicList instance) => DynamicList()
+  ..dynamicList = List<dynamic>.unmodifiable(
+      instance.dynamicList.map((e) => DynamicProtoMapper.fromProto(e)))
+  ..objectList = List<Object>.unmodifiable(
+      instance.objectList.map((e) => DynamicProtoMapper.fromProto(e)));
+
+extension $DynamicListProtoExtension on DynamicList {
+  GDynamicList toProto() => _$DynamicListToProto(this);
+  String toJson() => _$DynamicListToProto(this).writeToJson();
+
+  static DynamicList fromProto(GDynamicList proto) =>
+      _$DynamicListFromProto(proto);
+  static DynamicList fromJson(String json) =>
+      _$DynamicListFromProto(GDynamicList.fromJson(json));
+}
+
+extension $GDynamicListProtoExtension on GDynamicList {
+  DynamicList toDynamicList() => _$DynamicListFromProto(this);
+}

--- a/proto_mapper/test/lib/src/dynamic_mapper.g.dart
+++ b/proto_mapper/test/lib/src/dynamic_mapper.g.dart
@@ -1,0 +1,360 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+import 'package:decimal/decimal.dart';
+import 'package:protobuf/protobuf.dart';
+import '../grpc/google/protobuf/any.pb.dart';
+import '../grpc/any_host.pb.dart';
+import '../grpc/calc_parameters.pb.dart';
+import '../grpc/calc_result.pb.dart';
+import '../grpc/category.pb.dart';
+import '../grpc/component.pb.dart';
+import '../grpc/constructors_host.pb.dart';
+import '../grpc/empty.pb.dart';
+import '../grpc/ingredient.pb.dart';
+import '../grpc/key.pb.dart';
+import '../grpc/lists_host.pb.dart';
+import '../grpc/recipe.pb.dart';
+import '../grpc/utensils.pb.dart';
+import 'package:proto_generator_test/src/any_host.dart';
+import 'package:proto_generator_test/src/appliance_type.dart';
+import 'package:proto_generator_test/src/calc_parameters.dart';
+import 'package:proto_generator_test/src/calc_result.dart';
+import 'package:proto_generator_test/src/category.dart';
+import 'package:proto_generator_test/src/component.dart';
+import 'package:proto_generator_test/src/constructors_host.dart';
+import 'package:proto_generator_test/src/empty.dart';
+import 'package:proto_generator_test/src/ingredient.dart';
+import 'package:proto_generator_test/src/key.dart';
+import 'package:proto_generator_test/src/lists_host.dart';
+import 'package:proto_generator_test/src/recipe.dart';
+import 'package:proto_generator_test/src/recipe_type.dart';
+import 'package:proto_generator_test/src/utensils.dart';
+
+/// Generated Mapper class used for packing and unpacking "google.protobuf.Any" fields or values
+class DynamicProtoMapper {
+  static final TypeRegistry typeRegistry = TypeRegistry([
+    GDynamicObject(),
+    GDynamicMap(),
+    GDynamicSet(),
+    GDynamicList(),
+    GCalcParameters(),
+    GCalcResult(),
+    GCategory(),
+    GComponent(),
+    GConstructObject1(),
+    GConstructObject2(),
+    GConstructObject3(),
+    GConstructObject4(),
+    GConstructObject5(),
+    GConstructObject6(),
+    GConstructObject7(),
+    GConstructObject8(),
+    GEmpty(),
+    GIngredient(),
+    GKey(),
+    GListsHost(),
+    GRecipe(),
+    GKnife(),
+    GGarlicPress(),
+    GKitchen(),
+    GChef(),
+    GInventory(),
+    GPrecisionSubject()
+  ]);
+
+  static dynamic fromProto(Any proto) {
+    switch (proto.typeUrl) {
+      case 'type.protogenerator.test/String':
+        return utf8.decode(proto.value);
+      case 'type.protogenerator.test/int8':
+        return Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+      case 'type.protogenerator.test/int16':
+        return Uint8List.fromList(proto.value)
+            .buffer
+            .asByteData()
+            .getUint16(0, Endian.big);
+      case 'type.protogenerator.test/int32':
+        return Uint8List.fromList(proto.value)
+            .buffer
+            .asByteData()
+            .getUint32(0, Endian.big);
+      case 'type.protogenerator.test/int64':
+        return Uint8List.fromList(proto.value)
+            .buffer
+            .asByteData()
+            .getUint64(0, Endian.big);
+      case 'type.protogenerator.test/float32':
+        return Uint8List.fromList(proto.value)
+            .buffer
+            .asByteData()
+            .getFloat32(0, Endian.big);
+      case 'type.protogenerator.test/float64':
+        return Uint8List.fromList(proto.value)
+            .buffer
+            .asByteData()
+            .getFloat64(0, Endian.big);
+      case 'type.protogenerator.test/Null':
+        return null;
+      case 'type.protogenerator.test/Boolean':
+        return proto.value[0] == 1;
+      case 'type.protogenerator.test/Decimal':
+        return Decimal.parse(utf8.decode(proto.value));
+      case 'type.protogenerator.test/GDynamicObject':
+        return proto.unpackInto(GDynamicObject()).toDynamicObject();
+      case 'type.protogenerator.test/GDynamicMap':
+        return proto.unpackInto(GDynamicMap()).toDynamicMap();
+      case 'type.protogenerator.test/GDynamicSet':
+        return proto.unpackInto(GDynamicSet()).toDynamicSet();
+      case 'type.protogenerator.test/GDynamicList':
+        return proto.unpackInto(GDynamicList()).toDynamicList();
+      case 'type.protogenerator.test/GApplianceType':
+        final index =
+            Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+        return ApplianceType.values[index];
+      case 'type.protogenerator.test/GCalcParameters':
+        return proto.unpackInto(GCalcParameters()).toCalcParameters();
+      case 'type.protogenerator.test/GCalcResult':
+        return proto.unpackInto(GCalcResult()).toCalcResult();
+      case 'type.protogenerator.test/GCategory':
+        return proto.unpackInto(GCategory()).toCategory();
+      case 'type.protogenerator.test/GComponent':
+        return proto.unpackInto(GComponent()).toComponent();
+      case 'type.protogenerator.test/GConstructObject1':
+        return proto.unpackInto(GConstructObject1()).toConstructObject1();
+      case 'type.protogenerator.test/GConstructObject2':
+        return proto.unpackInto(GConstructObject2()).toConstructObject2();
+      case 'type.protogenerator.test/GConstructObject3':
+        return proto.unpackInto(GConstructObject3()).toConstructObject3();
+      case 'type.protogenerator.test/GConstructObject4':
+        return proto.unpackInto(GConstructObject4()).toConstructObject4();
+      case 'type.protogenerator.test/GConstructObject5':
+        return proto.unpackInto(GConstructObject5()).toConstructObject5();
+      case 'type.protogenerator.test/GConstructObject6':
+        return proto.unpackInto(GConstructObject6()).toConstructObject6();
+      case 'type.protogenerator.test/GConstructObject7':
+        return proto.unpackInto(GConstructObject7()).toConstructObject7();
+      case 'type.protogenerator.test/GConstructObject8':
+        return proto.unpackInto(GConstructObject8()).toConstructObject8();
+      case 'type.protogenerator.test/GEmpty':
+        return proto.unpackInto(GEmpty()).toEmpty();
+      case 'type.protogenerator.test/GIngredient':
+        return proto.unpackInto(GIngredient()).toIngredient();
+      case 'type.protogenerator.test/GKey':
+        return proto.unpackInto(GKey()).toKey();
+      case 'type.protogenerator.test/GListsHost':
+        return proto.unpackInto(GListsHost()).toListsHost();
+      case 'type.protogenerator.test/GRecipe':
+        return proto.unpackInto(GRecipe()).toRecipe();
+      case 'type.protogenerator.test/GRecipeTypes':
+        final index =
+            Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+        return RecipeTypes.values[index];
+      case 'type.protogenerator.test/GKnife':
+        return proto.unpackInto(GKnife()).toKnife();
+      case 'type.protogenerator.test/GGarlicPress':
+        return proto.unpackInto(GGarlicPress()).toGarlicPress();
+      case 'type.protogenerator.test/GKitchen':
+        return proto.unpackInto(GKitchen()).toKitchen();
+      case 'type.protogenerator.test/GChef':
+        return proto.unpackInto(GChef()).toChef();
+      case 'type.protogenerator.test/GInventory':
+        return proto.unpackInto(GInventory()).toInventory();
+      case 'type.protogenerator.test/GPrecisionSubject':
+        return proto.unpackInto(GPrecisionSubject()).toPrecisionSubject();
+      case 'type.protogenerator.test/GKnifeType':
+        final index =
+            Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+        return KnifeType.values[index];
+      case 'type.protogenerator.test/GChefType':
+        final index =
+            Uint8List.fromList(proto.value).buffer.asByteData().getUint8(0);
+        return ChefType.values[index];
+      default:
+        throw "${proto.typeUrl} not (yet) supported!";
+    }
+  }
+
+  static Any toProto(dynamic value) {
+    if (value is String) {
+      return Any(
+          value: utf8.encode(value),
+          typeUrl: 'type.protogenerator.test/String');
+    }
+    if (value is int) {
+      final byteSize = (value.bitLength / 8).ceil();
+      if (byteSize < 2) {
+        return Any(
+            value: Uint8List(1)..buffer.asByteData().setInt8(0, value),
+            typeUrl: 'type.protogenerator.test/int8');
+      } else if (byteSize < 3) {
+        return Any(
+            value: Uint8List(2)
+              ..buffer.asByteData().setInt16(0, value, Endian.big),
+            typeUrl: 'type.protogenerator.test/int16');
+      } else if (byteSize < 4) {
+        return Any(
+            value: Uint8List(4)
+              ..buffer.asByteData().setInt32(0, value, Endian.big),
+            typeUrl: 'type.protogenerator.test/int32');
+      } else {
+        return Any(
+            value: Uint8List(8)
+              ..buffer.asByteData().setInt64(0, value, Endian.big),
+            typeUrl: 'type.protogenerator.test/int64');
+      }
+    }
+    if (value is double) {
+      return Any(
+          value: Uint8List(8)
+            ..buffer.asByteData().setFloat64(0, value, Endian.big),
+          typeUrl: 'type.protogenerator.test/float64');
+    }
+    if (value == null) {
+      return Any(value: null, typeUrl: 'type.protogenerator.test/Null');
+    }
+    if (value is bool) {
+      return Any(
+          value: value ? [1] : [0],
+          typeUrl: 'type.protogenerator.test/Boolean');
+    }
+    if (value is Decimal) {
+      return Any(
+          value: utf8.encode(value.toString()),
+          typeUrl: 'type.protogenerator.test/Decimal');
+    }
+    if (value is DynamicObject) {
+      return Any.pack($DynamicObjectProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is DynamicMap) {
+      return Any.pack($DynamicMapProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is DynamicSet) {
+      return Any.pack($DynamicSetProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is DynamicList) {
+      return Any.pack($DynamicListProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ApplianceType) {
+      return Any(
+          value: Uint8List(max(1, (value.index.bitLength / 8).ceil()))
+            ..buffer.asByteData().setUint8(0, value.index),
+          typeUrl: 'type.protogenerator.test/GApplianceType');
+    }
+    if (value is CalcParameters) {
+      return Any.pack($CalcParametersProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is CalcResult) {
+      return Any.pack($CalcResultProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Category) {
+      return Any.pack($CategoryProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Component) {
+      return Any.pack($ComponentProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject1) {
+      return Any.pack($ConstructObject1ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject2) {
+      return Any.pack($ConstructObject2ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject3) {
+      return Any.pack($ConstructObject3ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject4) {
+      return Any.pack($ConstructObject4ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject5) {
+      return Any.pack($ConstructObject5ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject6) {
+      return Any.pack($ConstructObject6ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject7) {
+      return Any.pack($ConstructObject7ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ConstructObject8) {
+      return Any.pack($ConstructObject8ProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Empty) {
+      return Any.pack($EmptyProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Ingredient) {
+      return Any.pack($IngredientProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Key) {
+      return Any.pack($KeyProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is ListsHost) {
+      return Any.pack($ListsHostProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Recipe) {
+      return Any.pack($RecipeProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is RecipeTypes) {
+      return Any(
+          value: Uint8List(max(1, (value.index.bitLength / 8).ceil()))
+            ..buffer.asByteData().setUint8(0, value.index),
+          typeUrl: 'type.protogenerator.test/GRecipeTypes');
+    }
+    if (value is Knife) {
+      return Any.pack($KnifeProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is GarlicPress) {
+      return Any.pack($GarlicPressProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Kitchen) {
+      return Any.pack($KitchenProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Chef) {
+      return Any.pack($ChefProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is Inventory) {
+      return Any.pack($InventoryProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is PrecisionSubject) {
+      return Any.pack($PrecisionSubjectProtoMapper().toProto(value),
+          typeUrlPrefix: 'type.protogenerator.test');
+    }
+    if (value is KnifeType) {
+      return Any(
+          value: Uint8List(max(1, (value.index.bitLength / 8).ceil()))
+            ..buffer.asByteData().setUint8(0, value.index),
+          typeUrl: 'type.protogenerator.test/GKnifeType');
+    }
+    if (value is ChefType) {
+      return Any(
+          value: Uint8List(max(1, (value.index.bitLength / 8).ceil()))
+            ..buffer.asByteData().setUint8(0, value.index),
+          typeUrl: 'type.protogenerator.test/GChefType');
+    }
+    throw "${value.runtimeType} not (yet) supported!";
+  }
+}

--- a/proto_mapper/test/proto/any_host.proto
+++ b/proto_mapper/test/proto/any_host.proto
@@ -1,0 +1,60 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// ProtoGenerator
+// **************************************************************************
+
+syntax = "proto3";
+      
+
+
+
+
+message GDynamicObject
+{
+  google.protobuf.Any dynamic_property = 1;
+  google.protobuf.Any object_property = 2;
+}   
+
+message GListOfDynamicObject
+{
+  repeated GDynamicObject items = 1;
+}
+
+import "google/protobuf/any.proto";
+
+
+
+
+message GDynamicMap
+{
+  map<string, google.protobuf.Any> dynamic_map = 1;
+  map<string, google.protobuf.Any> object_map = 2;
+}   
+
+message GListOfDynamicMap
+{
+  repeated GDynamicMap items = 1;
+}
+
+message GDynamicSet
+{
+  repeated google.protobuf.Any dynamic_set = 1;
+  repeated google.protobuf.Any object_set = 2;
+}   
+
+message GListOfDynamicSet
+{
+  repeated GDynamicSet items = 1;
+}
+
+message GDynamicList
+{
+  repeated google.protobuf.Any dynamic_list = 1;
+  repeated google.protobuf.Any object_list = 2;
+}   
+
+message GListOfDynamicList
+{
+  repeated GDynamicList items = 1;
+}

--- a/proto_mapper/test/pubspec.yaml
+++ b/proto_mapper/test/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
 dependencies:
   proto_generator:
     path: ../proto_generator
-  # decimal: ^2.0.0
+  decimal: ^2.1.0
   # fixnum: ^1.0.0
   # grpc: ^3.0.0
 

--- a/proto_mapper/test/test/casing_test.dart
+++ b/proto_mapper/test/test/casing_test.dart
@@ -81,6 +81,7 @@ Recipe _scrambledEggsRecipe({
         ),
       ],
       title: 'Scrambled eggs',
+      description: 'gesg',
       preparationDuration: Duration(minutes: 23, seconds: 30),
       totalDuration: totalDuration,
       isPublished: true,

--- a/proto_mapper/test/test/dynamic_test.dart
+++ b/proto_mapper/test/test/dynamic_test.dart
@@ -1,0 +1,216 @@
+import 'package:decimal/decimal.dart';
+import 'package:proto_generator_test/grpc/any_host.pb.dart';
+import 'package:proto_generator_test/proto_generator_test.dart';
+import 'package:proto_generator_test/src/any_host.dart';
+import 'package:proto_generator_test/src/appliance_type.dart';
+import 'package:proto_generator_test/src/component.dart';
+import 'package:proto_generator_test/src/utensils.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Dynamic fields', ()
+  {
+    test('Null', () {
+      _runFieldTest(null);
+    });
+
+    test('Recipe', () {
+      _runFieldTest(_recipe());
+    });
+
+    test('String', () {
+      _runFieldTest('test');
+    });
+
+    test('Integer', () {
+      _runFieldTest(0);
+      _runFieldTest(0x7f);
+      _runFieldTest(0x7ff);
+      _runFieldTest(0x7fff);
+      _runFieldTest(0x7ffff);
+      _runFieldTest(0x7fffff);
+      _runFieldTest(0x7ffffff);
+      _runFieldTest(0x7fffffff);
+      _runFieldTest(0x7ffffffff);
+      _runFieldTest(0x7fffffffff);
+      _runFieldTest(0x7ffffffffff);
+      _runFieldTest(0x7fffffffffff);
+      _runFieldTest(0x7ffffffffffff);
+      _runFieldTest(0x7fffffffffffff);
+      _runFieldTest(0x7ffffffffffffff);
+      _runFieldTest(0x7fffffffffffffff);
+      _runFieldTest(9223372036854775807);
+      _runFieldTest(-9223372036854775807);
+    });
+
+    test('Double', () {
+      _runFieldTest(165.9872);
+      _runFieldTest(0.0);
+      _runFieldTest(0.9872);
+      _runFieldTest(double.maxFinite);
+      _runFieldTest(double.minPositive);
+    });
+
+    test('Boolean', () {
+      _runFieldTest(true);
+      _runFieldTest(false);
+    });
+
+    test('Decimal', () {
+      _runFieldTest(Decimal.fromInt(5));
+      _runFieldTest(Decimal.fromInt(655));
+      _runFieldTest(Decimal.fromInt(657855));
+    });
+
+    test('Enum', () {
+      _runFieldTest(KnifeType.chefsKnife);
+      _runFieldTest(KnifeType.breadKnife);
+      _runFieldTest(ChefType.seniorChef);
+    });
+  });
+
+  group('Dynamic collections', () {
+    test('DynamicMap', () {
+      final map = DynamicMap()..dynamicMap = {
+        "string": "One",
+        "int": 2,
+        "bool": true,
+        "decimal": Decimal.fromInt(654),
+        "recipe": _recipe(),
+        "dynamic": _dynamicObject(),
+        "double": 65.798,
+        "enum": KnifeType.chefsKnife,
+        "null": null
+      }..objectMap = {
+        "string": "One",
+        "int": 2,
+        "bool": true,
+        "decimal": Decimal.fromInt(654),
+        "recipe": _recipe(),
+        "dynamic": _dynamicObject(),
+        "double": 65.798,
+        "enum": KnifeType.chefsKnife,
+      };
+      final proto1 = map.toProto();
+      final json1 = proto1.writeToJson();
+      final proto2 = GDynamicMap.fromJson(json1);
+      final json2 = proto2.writeToJson();
+      expect(json1, equals(json2));
+      expect(proto1, equals(proto2));
+      print(json2);
+    });
+
+    test('DynamicSet', () {
+      final set = DynamicSet()..dynamicSet = {
+        "One",
+        2,
+        true,
+        Decimal.fromInt(654),
+        _recipe(),
+        _dynamicObject(),
+        65.798,
+        KnifeType.chefsKnife,
+        null
+      }..objectSet = {
+        "One",
+        2,
+        true,
+        Decimal.fromInt(654),
+        _recipe(),
+        _dynamicObject(),
+        65.798,
+        KnifeType.chefsKnife,
+      };
+      final proto1 = set.toProto();
+      final json1 = proto1.writeToJson();
+      final proto2 = GDynamicSet.fromJson(json1);
+      final json2 = proto2.writeToJson();
+      expect(json1, equals(json2));
+      expect(proto1, equals(proto2));
+      print(json2);
+    });
+
+    test('DynamicList', () {
+      final list = DynamicList()..dynamicList = [
+        "One",
+        2,
+        true,
+        Decimal.fromInt(654),
+        _recipe(),
+        _dynamicObject(),
+        65.798,
+        KnifeType.chefsKnife,
+        null
+      ]..objectList = [
+        "One",
+        2,
+        true,
+        Decimal.fromInt(654),
+        _recipe(),
+        _dynamicObject(),
+        65.798,
+        KnifeType.chefsKnife,
+      ];
+      final proto1 = list.toProto();
+      final json1 = proto1.writeToJson();
+      final proto2 = GDynamicList.fromJson(json1);
+      final json2 = proto2.writeToJson();
+      expect(json1, equals(json2));
+      expect(proto1, equals(proto2));
+      print(json2);
+    });
+  });
+}
+
+void _runFieldTest(dynamic prop) {
+  var object = DynamicObject()
+    ..dynamicProperty = prop
+    ..objectProperty = prop?? 'null';
+  var proto = object.toProto();
+  var serialized = object.toJson();
+  var deserializedJson = GDynamicObject.fromJson(serialized).toDynamicObject();
+  var deserializedProto = proto.toDynamicObject();
+  // Only works if Recipe implements equals method... That's why we just compare JSON and toString values
+  if (object.dynamicProperty is String) {
+    expect(object.dynamicProperty, equals(deserializedJson.dynamicProperty));
+    expect(object.dynamicProperty, equals(deserializedProto.dynamicProperty));
+  } else {
+    expect(object.dynamicProperty.toString(), equals(deserializedJson.dynamicProperty.toString()));
+    expect(object.dynamicProperty.toString(), equals(deserializedProto.dynamicProperty.toString()));
+  }
+  expect(object.toProto().writeToJson(), equals(serialized));
+  expect(object.toProto().writeToJson(), equals(deserializedJson.toJson()));
+  expect(object.toProto().writeToJson(), equals(deserializedProto.toJson()));
+  print(object.toJson());
+}
+
+DynamicObject _dynamicObject() {
+  DynamicObject object = DynamicObject()
+    ..dynamicProperty = _recipe()
+    ..objectProperty = _recipe();
+  return object;
+}
+
+Recipe _recipe() {
+  var lasagnaRecipe = Recipe(
+      title: "Lasagna",
+      category: Category(
+          title: "Sauce",
+          mainComponent: Component(description: "Red sauce"),
+          otherComponents: []),
+      ingredients: [
+        Ingredient(
+            description: "Tomatoes",
+            quantity: Decimal.ten,
+            precision: 1.2,
+            cookingDuration: Duration(minutes: 5),
+            mainComponent: Component(description: "Red sauce"),
+            otherComponents: [])
+      ],
+      publishDate: DateTime.now(),
+      preparationDuration: Duration(days: 10),
+      isPublished: false,
+      mainApplianceType: ApplianceType.heat,
+      tags: []);
+  return lasagnaRecipe;
+}


### PR DESCRIPTION
In order to be more flexible, I'd like to look into the option of mapping, packing and unpacking `dynamic` or `Object` typed values into `google.protobuf.Any` fields.

My current solution centers around a "code generated" `DynamicProtoMapper` class that will provide the mapping for primitive values, as well as all `@mapProto` annotated classes. 

The current branch reflects the "to be" situation, with the "hand-crafted" [dynamic_mapper.dart](https://github.com/BenVercammen/dart_framework/blob/dynamic_value_support/proto_mapper/test/lib/src/dynamic_mapper.g.dart) file. The only work that remains to be done, is create a code generator for that class. I'm currently "stuck" on that one, but already created an issue in the **source_gen** repo (https://github.com/dart-lang/source_gen/issues/586).

My first couple of questions:
 1. Would this be a good idea, or am I missing something obvious? To get a quick feeling of what I'm trying to accomplish...

**any_host.dart**:

```
import 'package:proto_annotations/proto_annotations.dart';
import 'package:proto_generator_test/grpc/any_host.pb.dart';
import 'package:proto_generator_test/src/dynamic_mapper.g.dart';

part 'any_host.g.dart';

@proto
@mapProto
class DynamicObject {
  late dynamic dynamicProperty;
}
```

**any_host.proto**:
```
syntax = "proto3";

import "google/protobuf/any.proto";

message GDynamicObject {
  google.protobuf.Any dynamic_property = 1;
}   
```


 2. Using this does require the `google/protobuf/any.proto` file, as well as the `protoc`-generated `any.pb[...].dart` files. I've added the information in the [README file](https://github.com/BenVercammen/dart_framework/blob/dynamic_value_support/proto_mapper/proto_generator/README.md). Is this a possible show-stopper, or is it reasonable to expect users to be able to set this up properly?
 3. I feel like the baseline "primitive mapping" code in `DynamicProtoMapper` can still be optimized (hence the TODO's in there). Any ideas, suggestions or warnings in that regards?
 4. Of course, this will only work for the known `@mapProto` annotated classes. So this is only a solution to be used within a single project. External projects using the generated `*.proto` files will have to create/build/generate their own mapping, but I don't really think that is an issue?
 5.  It also isn't a wildcard to be able to automatically map any incoming messages. Maybe we should make it possible to provide some sort of hook in order for users to extend the `DynamicProtoMapper` to support extra `typeUrl`'s? Some sort of custom mapping extensions? I currently don't know enough about the extension mechanism in dart, but it might be useful when one needs to map incoming messages from outside sources?

Any feedback or guidance on this issue would be highly appreciated!